### PR TITLE
String Export - Cobalt

### DIFF
--- a/locales/ar/app.po
+++ b/locales/ar/app.po
@@ -6,17 +6,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-26 05:56+0000\n"
 "Last-Translator: صفا الفليج <safa1996alfulaij@gmail.com>\n"
-"Language-Team: ar <LL@li.org>\n"
 "Language: ar\n"
+"Language-Team: ar <LL@li.org>\n"
+"Plural-Forms: nplurals=6; plural=((((n % 100) >= 3 && (n % 100) <= 10)) ?"
+" 3 : (((n % 100) >= 11 && (n % 100) <= 99)) ? 4 : ((n == 1)) ? 1 : ((n =="
+" 2)) ? 2 : ((n == 0)) ? 0 : 5)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -166,10 +167,12 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>يعطيك %1$s الدفة.</p>\n"
@@ -281,9 +284,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "أرسل بيانات استخدام مجهّلة"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "اطّلع على المزيد"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -319,6 +338,16 @@ msgstr "امسح تأريخ التصفح"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "وسِّع"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -429,8 +458,12 @@ msgstr "ابحث عن تطبيق يدعم فتح الرابط"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "لا يوجد أي تطبيق على جهازك يدعم فتح هذا الرابط. يمكنك مغادرة %1$s للبحث في %2$s عن تطبيق يدعم الرابط."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"لا يوجد أي تطبيق على جهازك يدعم فتح هذا الرابط. يمكنك مغادرة %1$s للبحث "
+"في %2$s عن تطبيق يدعم الرابط."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -488,13 +521,17 @@ msgstr "تعذّر الاتصال"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>قد يكون الموقع غير متاح مؤقتًا أو مشغولًا جدًا. حاول مجددًا بعد قليل.</li>\n"
-"        <li>إن لم تكن تستطيع تحميل أي صفحة، تحقق من اتصال جوّالك بشبكة البيانات أو الشبكة اللاسلكية.</li>\n"
+"        <li>قد يكون الموقع غير متاح مؤقتًا أو مشغولًا جدًا. حاول مجددًا "
+"بعد قليل.</li>\n"
+"        <li>إن لم تكن تستطيع تحميل أي صفحة، تحقق من اتصال جوّالك بشبكة "
+"البيانات أو الشبكة اللاسلكية.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -511,14 +548,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>تحقق من عدم وجود أي أخطاء في العنوان مثل\n"
 "          ‏‪<strong>ww</strong>.example.com‬ بدلًا من\n"
 "          ‏‪<strong>www</strong>.example.com‬‏</li>\n"
-"        <li>إن لم تكن قادرًا على تحميل أي صفحة، تحقق من اتصال جهازك بشبكة البيانات أو الشبكة اللاسلكية.</li>\n"
+"        <li>إن لم تكن قادرًا على تحميل أي صفحة، تحقق من اتصال جهازك بشبكة"
+" البيانات أو الشبكة اللاسلكية.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -528,13 +567,17 @@ msgstr "العنوان غير صالح"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>تُكتب عناوين الوب عادة على الشكل التالي <strong>‪http://www.example.com/‬</strong>‏</li>\n"
-"  <li>تأكد أنك تستخدم الشرطة المائلة إلى اليمين (أي <strong>/</strong>).</li> \n"
+"  <li>تُكتب عناوين الوب عادة على الشكل التالي "
+"<strong>‪http://www.example.com/‬</strong>‏</li>\n"
+"  <li>تأكد أنك تستخدم الشرطة المائلة إلى اليمين (أي "
+"<strong>/</strong>).</li> \n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -544,7 +587,8 @@ msgstr "لا تعيد الصفحة التوجيه بشكل سليم"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -558,7 +602,8 @@ msgstr "العنوان غير مفهوم"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -572,9 +617,11 @@ msgstr "فشل الاتصال الآمن"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
@@ -627,7 +674,9 @@ msgstr "افتح الرابط في لسان جديد"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
 msgstr "الصور المحفوظة و المُشاركة <b>لن تُحذف</b> عندما تمسح تأريخ %1$s."
 
 #. First run tour (Default browser): Title
@@ -637,8 +686,12 @@ msgstr "حسّن خصوصيتك"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "انتقل بالتصفّح الخاص إلى المستوى التالي. احجب الإعلانات وغيرها من المحتويات التي تتعقبك أثناء التصفح وتأخذ من وقت تحميل الصفحات."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"انتقل بالتصفّح الخاص إلى المستوى التالي. احجب الإعلانات وغيرها من "
+"المحتويات التي تتعقبك أثناء التصفح وتأخذ من وقت تحميل الصفحات."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,7 +700,9 @@ msgstr "تبحثُ بأسلوبك أنت"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "أتبحث عن شيء مختلف؟ اختر محرّك بحث آخر ليكون المبدئي من الإعدادات."
 
 #. First run tour (Shortcut): Title
@@ -659,8 +714,12 @@ msgstr "أضف اختصارات إلى الشاشة الرئيسية"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "عُد إلى مواقعك المفضلة في %1$s بسرعة. اختر ”أضف إلى الشاشة الرئيسية“ من قائمة %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"عُد إلى مواقعك المفضلة في %1$s بسرعة. اختر ”أضف إلى الشاشة الرئيسية“ من "
+"قائمة %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +730,12 @@ msgstr "اجعل من الخصوصية عادة"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "اضبط %1$s ليكون المتصفّح المبدئي وتمتع بفوائد التصفح الخاص عندما تفتح موقعا من تطبيق آخر."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"اضبط %1$s ليكون المتصفّح المبدئي وتمتع بفوائد التصفح الخاص عندما تفتح "
+"موقعا من تطبيق آخر."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +773,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "ألغِ"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +796,36 @@ msgstr "افتح الرابط في اللسان المحدّد"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "افتح"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/ast/app.po
+++ b/locales/ast/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-13 17:46+0000\n"
 "Last-Translator: Enol <enolp@softastur.org>\n"
 "Language: ast\n"
@@ -274,9 +274,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Unviar datos anónimos d'usu"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Deprendi más"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -311,6 +327,16 @@ msgstr "Desaniciar historial de restolar"
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -700,6 +726,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Encaboxar"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -714,5 +748,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/az/app.po
+++ b/locales/az/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-27 12:22+0000\n"
 "Last-Translator: Emin Mastizada <emin@mastizada.com>\n"
-"Language-Team: az <LL@li.org>\n"
 "Language: az\n"
+"Language-Team: az <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,10 +167,12 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s sizi idarənin başına qoyur</p>\n"
@@ -182,7 +183,8 @@ msgstr ""
 "    <li>Çərəzləri, axtarış və gəzmə tarixçəsini silmək üçün pozun</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s qürurla Mozilla tərəfindən. Missiyamız sağlam və açıq interneti təmin etməkdir.<br/>\n"
+"<p>%1$s qürurla Mozilla tərəfindən. Missiyamız sağlam və açıq interneti "
+"təmin etməkdir.<br/>\n"
 "<a href=\"%2$s\">Ətraflı öyrən</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +285,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Anonim istifadə məlumatlarını göndər"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Ətraflı öyrən"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +339,16 @@ msgstr "Səyahət tarixçəsini təmizlə"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Genişlət"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +459,12 @@ msgstr "Keçid aça bilən tətbiq tap"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Cihazınızdakı heç bir tətbiq bu keçidi aça bilmir. %1$s səyyahını tərk edərək %2$s ilə bunu bacaran tətbiq axtara bilərsiz."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Cihazınızdakı heç bir tətbiq bu keçidi aça bilmir. %1$s səyyahını tərk "
+"edərək %2$s ilə bunu bacaran tətbiq axtara bilərsiz."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -490,13 +522,17 @@ msgstr "Qoşulmaq mümkün olmadı"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Sayt müvəqqəti olaraq əlçatmaz və ya çox məşğul ola bilər. Biraz sonra təkrar yoxlayın.</li>\n"
-"        <li>Əgər heç bir səhifəni yükləyə bilmirsizsə, mobil cihazınızın internet datasını və ya Wi-Fi bağlantısını yoxlayın.</li>\n"
+"        <li>Sayt müvəqqəti olaraq əlçatmaz və ya çox məşğul ola bilər. "
+"Biraz sonra təkrar yoxlayın.</li>\n"
+"        <li>Əgər heç bir səhifəni yükləyə bilmirsizsə, mobil cihazınızın "
+"internet datasını və ya Wi-Fi bağlantısını yoxlayın.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +549,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Ünvanı <strong>www</strong>.example.com\n"
 "          yerinə <strong>ww</strong>.example.com kimi\n"
 "          yazma xətaları üçün təkrar yaxlayın</li>\n"
-"        <li>Əgər heç bir saytı yükləyə bilmirsizsə, cihazınızın data və ya Wi-Fi bağlantısını yoxlayın.</li>\n"
+"        <li>Əgər heç bir saytı yükləyə bilmirsizsə, cihazınızın data və "
+"ya Wi-Fi bağlantısını yoxlayın.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +568,17 @@ msgstr "Ünvan səhvdir"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Sayt ünvanları əsasən <strong>http://www.example.com/</strong> kimi yazılırlar.</li>\n"
-"  <li>Əyri kəsmə işarəsindən (yani <strong>/</strong>) istifadə etdiyinizdən əmin olun.</li>\n"
+"  <li>Sayt ünvanları əsasən <strong>http://www.example.com/</strong> kimi"
+" yazılırlar.</li>\n"
+"  <li>Əyri kəsmə işarəsindən (yani <strong>/</strong>) istifadə "
+"etdiyinizdən əmin olun.</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +588,13 @@ msgstr "Səhifə düzgün yönləndirilmir"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Bu problem çox vaxt çərəzləri qapatmaqdan və ya qəbul etməyi ləğv etməkdən olur.</li>\n"
+"  <li>Bu problem çox vaxt çərəzləri qapatmaqdan və ya qəbul etməyi ləğv "
+"etməkdən olur.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +604,13 @@ msgstr "Ünvan başa düşülmədi"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Bu ünvanı açmaq üçün başqa bir tətbiq qurmanıza ehtiyyac ola bilər.</li>\n"
+"  <li>Bu ünvanı açmaq üçün başqa bir tətbiq qurmanıza ehtiyyac ola "
+"bilər.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +620,19 @@ msgstr "Təhlükəsiz bağlantı qurulmadı"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Bu serverin konfiqurasiyası ilə və ya birilərinin serverə hücüm etməsi ilə bağlı ola bilər.</li>\n"
-"  <li>Əgər daha sonra bu serverə uğurlu bağlana bilmişdinizsə, bu xəta müvəqqəti ola bilər və daha sonra təkrar yoxlaya bilərsiz.</li>\n"
+"  <li>Bu serverin konfiqurasiyası ilə və ya birilərinin serverə hücüm "
+"etməsi ilə bağlı ola bilər.</li>\n"
+"  <li>Əgər daha sonra bu serverə uğurlu bağlana bilmişdinizsə, bu xəta "
+"müvəqqəti ola bilər və daha sonra təkrar yoxlaya bilərsiz.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +677,12 @@ msgstr "Keçidi yeni vərəqdə aç"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Saxlanılan və paylaşılan şəkillər %1$s tarixini pozduqda <b>silinməyəcəklər</b>."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Saxlanılan və paylaşılan şəkillər %1$s tarixini pozduqda "
+"<b>silinməyəcəklər</b>."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +691,13 @@ msgstr "Məxfiliyinizi gücləndirin"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Məxfi səyahəti fərqli səviyyəyə götürün. Saytlar üzərindən sizə izləyə biləcək reklam və digər məzmunları bloklayın və yüklənmə sürətini artırın."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Məxfi səyahəti fərqli səviyyəyə götürün. Saytlar üzərindən sizə izləyə "
+"biləcək reklam və digər məzmunları bloklayın və yüklənmə sürətini "
+"artırın."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,7 +706,9 @@ msgstr "Sizin axtarış, sizin qaydalar"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "Fərqli şeylər axtarırsız? Tənzimləmələrdən fərqli axtarış mühərriyi seçin."
 
 #. First run tour (Shortcut): Title
@@ -659,8 +720,12 @@ msgstr "Ana ekranınıza keçidlər əlavə edin"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "%1$s üzərindəki sevimli saytlarınıza cəld girin. %1$s menyusundan \"Ana ekrana əlavə et\" seçməyiniz kifayətdir."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"%1$s üzərindəki sevimli saytlarınıza cəld girin. %1$s menyusundan \"Ana "
+"ekrana əlavə et\" seçməyiniz kifayətdir."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +736,12 @@ msgstr "Məxfiliyi vərdiş halına gətirin"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Əsas səyyahınız olaraq %1$s seçin və digər tətbiqlərdən keçid açarkən məxfi səyahətin üstünlüklərindən faydalanın."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Əsas səyyahınız olaraq %1$s seçin və digər tətbiqlərdən keçid açarkən "
+"məxfi səyahətin üstünlüklərindən faydalanın."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +779,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Ləğv et"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +802,36 @@ msgstr "Keçidi seçilmiş vərəqdə aç"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Aç"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/bg/app.po
+++ b/locales/bg/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-07 13:02+0000\n"
 "Last-Translator: :stoyan <stoyan@gmx.com>\n"
 "Language: bg\n"
@@ -287,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Изпращане на анонимни данни за използването"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Научете повече"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -324,6 +340,16 @@ msgstr "Изчистване историята на разглеждането"
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -747,6 +773,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Отказ"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -761,5 +795,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/bn-BD/app.po
+++ b/locales/bn-BD/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-12 18:56+0000\n"
 "Last-Translator: Belayet Hossain <bellayet@gmail.com>\n"
 "Language: bn_BD\n"
@@ -287,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "ব্যবহার সম্পর্কিত ডাটা ছদ্মনামে প্রেরণ করুন"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "আরও জানুন"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -324,6 +340,16 @@ msgstr "ব্রাউজিং ইতিহাস পরিষ্কার ক
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -749,6 +775,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "বাতিল"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -763,5 +797,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/bn-IN/app.po
+++ b/locales/bn-IN/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-23 08:18+0000\n"
 "Last-Translator: Biraj  Karmakar <brnet00@gmail.com>\n"
-"Language-Team: bn_IN <LL@li.org>\n"
 "Language: bn_IN\n"
+"Language-Team: bn_IN <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 0)) || ((n == 1))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s আপনাকে নিয়ন্ত্রণ দেয়।</p>\n"
 "<p>ব্যক্তিগত ব্রাউজার হিসাবে এটিকে ব্যবহার করুন:\n"
 "  <ul>\n"
 "    <li>অ্যাপের মধ্যেই অনুসন্ধান এবং ব্রাউজ করুন</li>\n"
-"    <li>ট্রাকারদেরকে অবরুদ্ধ করুন (অথবা ট্রাকারদের অনুমতি দিতে সেটিংস আপডেট করুন)</li>\n"
-"    <li>সেইসাথে অনুসন্ধান এবং ব্রাউজিংয়ের পূর্ববর্তী তথ্যকে কুকির সাথে মুছুন</li>\n"
+"    <li>ট্রাকারদেরকে অবরুদ্ধ করুন (অথবা ট্রাকারদের অনুমতি দিতে সেটিংস "
+"আপডেট করুন)</li>\n"
+"    <li>সেইসাথে অনুসন্ধান এবং ব্রাউজিংয়ের পূর্ববর্তী তথ্যকে কুকির সাথে "
+"মুছুন</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s তৈরী করেছে Mozilla। আমাদের মিশন হচ্ছে, ইন্টারনেটকে উন্মুক্ত রাখা এবং সেটির গুণগত মান বজায় রাখতে উৎসাহ দেওয়া।<br/>\n"
+"<p>%1$s তৈরী করেছে Mozilla। আমাদের মিশন হচ্ছে, ইন্টারনেটকে উন্মুক্ত রাখা "
+"এবং সেটির গুণগত মান বজায় রাখতে উৎসাহ দেওয়া।<br/>\n"
 "<a href=\"%2$s\">আরও জানুন</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "নামবিহীন ব্যাবহার করা তথ্য পাঠান"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "আরও জানুন"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "ব্রাউসারের পূর্ববর্তী তথ্�
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "প্রসারিত করুন"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "একটি অ্যাপ অনুসন্ধান করেন �
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "আপনার ডিভাইসের কোন অ্যাপই এই লিঙ্কটি খুলতে সক্ষম হয়নি। %2$s অনুসন্ধান করে একটি অ্যাপ বের করার জন্যে আপনি %1$s কে দ্বায়িত্ব দিতে পারেন।"
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"আপনার ডিভাইসের কোন অ্যাপই এই লিঙ্কটি খুলতে সক্ষম হয়নি। %2$s অনুসন্ধান "
+"করে একটি অ্যাপ বের করার জন্যে আপনি %1$s কে দ্বায়িত্ব দিতে পারেন।"
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -490,13 +524,17 @@ msgstr "সংযোগ করতে ব্যর্থ"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>সাইটটি সাময়িকভাবে পাওয়া যাচ্ছেনা বা প্রচন্ড ব্যস্ত রয়েছে। কিছুক্ষণ পর আবার চেষ্টা করুন.</li>\n"
-"        <li>যদি আপনি কোন পেজ লোড করতে ব্যর্থ হন, আপনার ডিভাইসের মোবাইল ডেটা বা ওয়াইফাই সংযোগ পরীক্ষা করুন।</li>\n"
+"        <li>সাইটটি সাময়িকভাবে পাওয়া যাচ্ছেনা বা প্রচন্ড ব্যস্ত রয়েছে। "
+"কিছুক্ষণ পর আবার চেষ্টা করুন.</li>\n"
+"        <li>যদি আপনি কোন পেজ লোড করতে ব্যর্থ হন, আপনার ডিভাইসের মোবাইল "
+"ডেটা বা ওয়াইফাই সংযোগ পরীক্ষা করুন।</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +551,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>টাইপজনিত ভুলের জন্য ঠিকানা পরীক্ষা করুন যেমন\n"
 "          <strong>ww</strong>.example.com বদলে\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>যদি আপনি কোন পেজ লোড করতে ব্যর্থ হন, আপনার ডিভাইসের মোবাইল ডেটা বা ওয়াইফাই সংযোগ পরীক্ষা করুন।</li>\n"
+"        <li>যদি আপনি কোন পেজ লোড করতে ব্যর্থ হন, আপনার ডিভাইসের মোবাইল "
+"ডেটা বা ওয়াইফাই সংযোগ পরীক্ষা করুন।</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +570,17 @@ msgstr "ঠিকানাটি বৈধ নয়"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>ওয়েব ঠিকানা সাধারণত যেভাবে লেখা হয় <strong>http://www.example.com/</strong></li>\n"
-"  <li>আপনি যে ফরোয়ার্ড স্ল্যাস ব্যবহার করছেন তা নিশ্চিত করুন (অর্থাৎ <strong>/</strong>)।</li>\n"
+"  <li>ওয়েব ঠিকানা সাধারণত যেভাবে লেখা হয় "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>আপনি যে ফরোয়ার্ড স্ল্যাস ব্যবহার করছেন তা নিশ্চিত করুন (অর্থাৎ "
+"<strong>/</strong>)।</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +590,13 @@ msgstr "পেজ থেকে সঠিকরূপে অনুরোধ প�
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>কুকি নিষ্ক্রিয় অথবা প্রত্যাখ্যান করা হলে এই সমস্যা দেখা দেওয়ার সম্ভাবনা রয়েছে।</li>\n"
+"  <li>কুকি নিষ্ক্রিয় অথবা প্রত্যাখ্যান করা হলে এই সমস্যা দেখা দেওয়ার "
+"সম্ভাবনা রয়েছে।</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +606,13 @@ msgstr "ঠিকানাটি বোঝা যায়নি"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>চিহ্নিত ঠিকানা খোলার জন্য সম্ভবত কয়েকটি সফ্টওয়্যার ইনস্টল করা আবশ্যক।</li>\n"
+"  <li>চিহ্নিত ঠিকানা খোলার জন্য সম্ভবত কয়েকটি সফ্টওয়্যার ইনস্টল করা "
+"আবশ্যক।</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,17 +622,22 @@ msgstr "নিরাপদ সংযোগ স্থাপন করতে ব�
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>সার্ভারের কনফিগারেশনের ত্রুটির কারণে এই সমস্যাটি হতে পারে, অথবা হতে পারে \n"
+"  <li>সার্ভারের কনফিগারেশনের ত্রুটির কারণে এই সমস্যাটি হতে পারে, অথবা হতে"
+" পারে \n"
 "কেউ সার্ভারের ছদ্মবেশ ধারণ করার চেষ্টা করছেন।</li>\n"
-"  <li>যদি পূর্বে আপনি কখনো এই সার্ভারের সাথে সংযুক্ত হয়ে থাকেন, তাহলে সমস্যাটি\n"
-"অস্থায়ী হতে পারে, এবং আপনি কিছুক্ষণ পর আবার চেষ্টা করে দেখতে পারেন।</li>\n"
+"  <li>যদি পূর্বে আপনি কখনো এই সার্ভারের সাথে সংযুক্ত হয়ে থাকেন, তাহলে "
+"সমস্যাটি\n"
+"অস্থায়ী হতে পারে, এবং আপনি কিছুক্ষণ পর আবার চেষ্টা করে দেখতে পারেন।</li>"
+"\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -629,7 +682,9 @@ msgstr ""
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
 msgstr ""
 
 #. First run tour (Default browser): Title
@@ -639,7 +694,9 @@ msgstr ""
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
 msgstr ""
 
 #. First run tour (Search): Title
@@ -649,7 +706,9 @@ msgstr ""
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr ""
 
 #. First run tour (Shortcut): Title
@@ -661,7 +720,9 @@ msgstr ""
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
 msgstr ""
 
 #. First run tour (Privacy): Title
@@ -673,7 +734,9 @@ msgstr ""
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
 msgstr ""
 
 msgctxt "firstrun_close_button"
@@ -712,6 +775,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr ""
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -727,3 +798,36 @@ msgstr ""
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "খুলুন"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/ca/app.po
+++ b/locales/ca/app.po
@@ -6,17 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-17 21:50+0000\n"
 "Last-Translator: Jordi Serratosa <jordis@softcatala.cat>\n"
-"Language-Team: ca <LL@li.org>\n"
 "Language: ca\n"
+"Language-Team: ca <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 1)) && ((0 == 0))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -166,21 +165,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>El %1$s us dóna el control.</p>\n"
 "<p>Com a navegador privat, us permet:\n"
 "  <ul>\n"
 "    <li>Cercar i navegar directament des de l'aplicació</li>\n"
-"    <li>Blocar els elements de seguiment (o canviar els paràmetres per permetre'ls)</li>\n"
-"    <li>Esborrar les galetes i l'historial de cerques i de navegació</li>\n"
+"    <li>Blocar els elements de seguiment (o canviar els paràmetres per "
+"permetre'ls)</li>\n"
+"    <li>Esborrar les galetes i l'historial de cerques i de navegació</li>"
+"\n"
 "  </ul>\n"
 "</p>\n"
-"<p>El %1$s està creat per Mozilla. La nostra missió és fomentar un Internet obert i saludable.<br/>\n"
+"<p>El %1$s està creat per Mozilla. La nostra missió és fomentar un "
+"Internet obert i saludable.<br/>\n"
 "<a href=\"%2$s\">Més informació</a></p>"
 
 msgctxt "preference_category_search"
@@ -281,9 +285,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Envia dades d'ús anònimes"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Més informació"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -319,6 +339,16 @@ msgstr "Esborra l'historial de navegació"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Amplia"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -429,8 +459,13 @@ msgstr "Cerca una aplicació que pugui obrir aquest enllaç"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "No hi ha cap aplicació en el dispositiu que pugui obrir aquest enllaç. Podeu sortir del %1$s per cercar al %2$s una aplicació que pugui obrir-lo."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"No hi ha cap aplicació en el dispositiu que pugui obrir aquest enllaç. "
+"Podeu sortir del %1$s per cercar al %2$s una aplicació que pugui obrir-"
+"lo."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -455,7 +490,9 @@ msgstr "Obre"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Els fitxers que baixeu <b>no s'eliminaran</b> quan esborreu l'historial del %1$s."
+msgstr ""
+"Els fitxers que baixeu <b>no s'eliminaran</b> quan esborreu l'historial "
+"del %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -488,13 +525,17 @@ msgstr "No s'ha pogut connectar"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>El lloc web podria estar temporalment no disponible o massa ocupat. Torneu-ho a provar d'aquí uns moments.</li>\n"
-"        <li>Si no podeu carregar cap pàgina, comproveu la connexió de dades o Wi-Fi del vostre dispositiu mòbil.</li>\n"
+"        <li>El lloc web podria estar temporalment no disponible o massa "
+"ocupat. Torneu-ho a provar d'aquí uns moments.</li>\n"
+"        <li>Si no podeu carregar cap pàgina, comproveu la connexió de "
+"dades o Wi-Fi del vostre dispositiu mòbil.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -511,14 +552,17 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Comproveu que no s'hagin introduït errors en teclejar l'adreça, p. ex.\n"
+"        <li>Comproveu que no s'hagin introduït errors en teclejar "
+"l'adreça, p. ex.\n"
 "          <strong>ww</strong>.example.com en comptes de\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Si no podeu carregar cap pàgina, comproveu la connexió de dades o Wi-Fi del vostre dispositiu.</li>\n"
+"        <li>Si no podeu carregar cap pàgina, comproveu la connexió de "
+"dades o Wi-Fi del vostre dispositiu.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -528,13 +572,17 @@ msgstr "L'adreça no és vàlida"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Les adreces web normalment s'escriuen així: <strong>http://www.example.com/</strong></li>\n"
-"  <li>Assegureu-vos que utilitzeu les barres inclinades (<strong>/</strong>).</li>\n"
+"  <li>Les adreces web normalment s'escriuen així: "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Assegureu-vos que utilitzeu les barres inclinades "
+"(<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -544,11 +592,13 @@ msgstr "La pàgina no està redirigint correctament"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"<li>Això podria passar per haver inhabilitat o rebutjat l'acceptació de galetes.</li> \n"
+"<li>Això podria passar per haver inhabilitat o rebutjat l'acceptació de "
+"galetes.</li> \n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -558,11 +608,13 @@ msgstr "No s'ha entès l'adreça"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Pot ser que calgui que instal·leu altre programari per obrir l'adreça.</li>\n"
+"  <li>Pot ser que calgui que instal·leu altre programari per obrir "
+"l'adreça.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -572,15 +624,19 @@ msgstr "Ha fallat la connexió segura"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Això podria ser un problema amb la configuració del servidor, o bé podria ser que algú estigués intentant fer-se passar pel servidor.</li>\n"
-"  <li>Si us hi heu connectat sense cap problema alguna altra vegada, l'error podria ser temporal i podeu tornar-ho a provar més tard.</li>\n"
+"  <li>Això podria ser un problema amb la configuració del servidor, o bé "
+"podria ser que algú estigués intentant fer-se passar pel servidor.</li>\n"
+"  <li>Si us hi heu connectat sense cap problema alguna altra vegada, "
+"l'error podria ser temporal i podeu tornar-ho a provar més tard.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -625,8 +681,12 @@ msgstr "Obre l'enllaç en una pestanya nova"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Les imatges que deseu i compartiu <b>no s'eliminaran</b> quan esborreu l'historial del %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Les imatges que deseu i compartiu <b>no s'eliminaran</b> quan esborreu "
+"l'historial del %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -635,8 +695,12 @@ msgstr "Potencieu la privadesa"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Porteu la navegació privada al nivell superior. Bloqueu anuncis i altre contingut que us fan el seguiment i alenteixen la càrrega de les pàgines."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Porteu la navegació privada al nivell superior. Bloqueu anuncis i altre "
+"contingut que us fan el seguiment i alenteixen la càrrega de les pàgines."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -645,8 +709,12 @@ msgstr "Cerqueu com vulgueu"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Busqueu una altra cosa? Trieu un altre motor de cerca per defecte als Paràmetres."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Busqueu una altra cosa? Trieu un altre motor de cerca per defecte als "
+"Paràmetres."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -657,8 +725,12 @@ msgstr "Afegiu dreceres a la pantalla d'inici"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Retorneu ràpidament als vostres llocs preferits amb el %1$s. Trieu «Afegeix a la pantalla d'inici» en el menú del %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Retorneu ràpidament als vostres llocs preferits amb el %1$s. Trieu "
+"«Afegeix a la pantalla d'inici» en el menú del %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -669,8 +741,12 @@ msgstr "Feu de la privadesa un hàbit"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Definiu el %1$s com a navegador per defecte i gaudiu d'una navegació privada quan obriu pàgines web des d'altres aplicacions."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Definiu el %1$s com a navegador per defecte i gaudiu d'una navegació "
+"privada quan obriu pàgines web des d'altres aplicacions."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -708,6 +784,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Cancel·la"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -723,3 +807,36 @@ msgstr "Obre l'enllaç en la pestanya seleccionada"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Obre"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/cs/app.po
+++ b/locales/cs/app.po
@@ -2,23 +2,23 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-21 17:19+0000\n"
 "Last-Translator: Michal Vašíček <michalvasicek@icloud.com>\n"
-"Language-Team: cs <LL@li.org>\n"
 "Language: cs\n"
+"Language-Team: cs <LL@li.org>\n"
+"Plural-Forms: nplurals=4; plural=((((n >= 2 && n <= 4)) && ((0 == 0))) ? "
+"1 : (!((0 == 0))) ? 2 : (((n == 1)) && ((0 == 0))) ? 0 : 3)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +168,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s vám dává kontrolu.</p>\n"
 "<p>Používejte ho jako soukromý prohlížeč:\n"
 "  <ul>\n"
 "    <li>Vyhledávejte a prohlížejte přímo v aplikaci</li>\n"
-"    <li>Blokujte sledovací prvky (nebo aktualizujte nastavení pro povolení sledovacích prvků)</li>\n"
-"    <li>Tlačítkem smažte cookies a historii vyhledávání a prohlížení</li>\n"
+"    <li>Blokujte sledovací prvky (nebo aktualizujte nastavení pro "
+"povolení sledovacích prvků)</li>\n"
+"    <li>Tlačítkem smažte cookies a historii vyhledávání a prohlížení</li>"
+"\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s je vyvíjen Mozillou. Naší misí je podporovat zdravý a otevřený internet.<br/>\n"
+"<p>%1$s je vyvíjen Mozillou. Naší misí je podporovat zdravý a otevřený "
+"internet.<br/>\n"
 "<a href=\"%2$s\">Zjistěte více</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +288,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Odesílat anonymní data o používání"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Zjistit více"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +342,16 @@ msgstr "Vymazat historii prohlížení"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Rozbalit"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +462,12 @@ msgstr "Najít aplikaci, která může otevřít odkaz"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Žádná z aplikací na vašem zařízení není schopná otevřít tento odkaz. Můžete opustit aplikaci %1$s a najít vhodnou aplikaci v %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Žádná z aplikací na vašem zařízení není schopná otevřít tento odkaz. "
+"Můžete opustit aplikaci %1$s a najít vhodnou aplikaci v %2$s."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +492,9 @@ msgstr "Otevřít"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Stažené soubory <b>nebudou odstraněny</b> při vymazání historie prohlížení aplikace %1$s."
+msgstr ""
+"Stažené soubory <b>nebudou odstraněny</b> při vymazání historie "
+"prohlížení aplikace %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +527,17 @@ msgstr "Nepodařilo se připojit"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Stránka může být dočasně nedostupná nebo zaneprázdněná. Zkuste to znovu za pár okamžiků.</li>\n"
-"        <li>Pokud nemůžete načíst žádnou stránku, zkontrolujte vaše mobilní data nebo Wi-Fi připojení.</li>\n"
+"        <li>Stránka může být dočasně nedostupná nebo zaneprázdněná. "
+"Zkuste to znovu za pár okamžiků.</li>\n"
+"        <li>Pokud nemůžete načíst žádnou stránku, zkontrolujte vaše "
+"mobilní data nebo Wi-Fi připojení.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +554,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Zkontrolujte adresu pro překlepy, jako například\n"
 "          <strong>ww</strong>.example.com místo\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Pokud nemůžete načíst žádnou stránku, zkontrolujte vaše mobilní data nebo Wi-Fi připojení.</li>\n"
+"        <li>Pokud nemůžete načíst žádnou stránku, zkontrolujte vaše "
+"mobilní data nebo Wi-Fi připojení.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +573,17 @@ msgstr "Neplatná adresa"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Webové adresy jsou obvykle psány jako <strong>http://www.example.com/</strong></li>\n"
-"  <li>Ujistěte se, že používáte běžná lomítka (tj. <strong>/</strong>).</li>\n"
+"  <li>Webové adresy jsou obvykle psány jako "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Ujistěte se, že používáte běžná lomítka (tj. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +593,13 @@ msgstr "Smyčka při přesměrování"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Tento problém může být způsobem zakázáním nebo odmítnutím cookies.</li>\n"
+"  <li>Tento problém může být způsobem zakázáním nebo odmítnutím "
+"cookies.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +609,13 @@ msgstr "Adresa nebyla rozpoznána"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Pro otevření této adresy budete patrně potřebovat nainstalovat další software.</li>\n"
+"  <li>Pro otevření této adresy budete patrně potřebovat nainstalovat "
+"další software.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +625,19 @@ msgstr "Chyba zabezpečeného spojení"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Tohle může být problém s konfigurací serveru, nebo je možné, že se za tento server někdo snaží vydávat.</li>\n"
-"  <li>Pokud jste se k tomuto serveru v minulosti připojili úspěšně, může jít o dočasnou chybu a můžete to zkusit znovu později.</li>\n"
+"  <li>Tohle může být problém s konfigurací serveru, nebo je možné, že se "
+"za tento server někdo snaží vydávat.</li>\n"
+"  <li>Pokud jste se k tomuto serveru v minulosti připojili úspěšně, může "
+"jít o dočasnou chybu a můžete to zkusit znovu později.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +682,12 @@ msgstr "Otevřít odkaz v novém panelu"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Uložené a sdílené obrázky <b>nebudou smazány</b> když smažete historii aplikace %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Uložené a sdílené obrázky <b>nebudou smazány</b> když smažete historii "
+"aplikace %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +696,12 @@ msgstr "Posuňte své soukromí na vyšší úroveň"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Anonymní prohlížení dostalo nový rozměr. Blokuje reklamy a další obsah, který vás sleduje napříč stránkami a zpomaluje načítání."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Anonymní prohlížení dostalo nový rozměr. Blokuje reklamy a další obsah, "
+"který vás sleduje napříč stránkami a zpomaluje načítání."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +710,12 @@ msgstr "Vaše hledání, vaše cesta"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Hledáte něco jiného? V nastavení si zvolte jiný vyhledávací modul jako výchozí."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Hledáte něco jiného? V nastavení si zvolte jiný vyhledávací modul jako "
+"výchozí."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +726,12 @@ msgstr "Přidejte si zkratky na vaši domovskou obrazovku"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "S aplikací %1$s se můžete rychle vrátit ke svým oblíbeným stránkám. Použijte „Přidat na domovskou obrazovku“ z nabídky aplikace %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"S aplikací %1$s se můžete rychle vrátit ke svým oblíbeným stránkám. "
+"Použijte „Přidat na domovskou obrazovku“ z nabídky aplikace %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +742,12 @@ msgstr "Udělejte ze soukromí zvyk"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Nastavte si %1$s jako svůj výchozí prohlížeč a získejte výhody soukromého prohlížení kdykoliv otevřete odkaz z ostatních aplikací."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Nastavte si %1$s jako svůj výchozí prohlížeč a získejte výhody soukromého"
+" prohlížení kdykoliv otevřete odkaz z ostatních aplikací."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +785,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Zrušit"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +808,36 @@ msgstr "Otevřít odkaz ve vybraném panelu"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Otevřít"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/cy/app.po
+++ b/locales/cy/app.po
@@ -6,17 +6,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 14:31+0000\n"
 "Last-Translator: Rhoslyn Prys <rprys@yahoo.com>\n"
-"Language-Team: cy <LL@li.org>\n"
 "Language: cy\n"
+"Language-Team: cy <LL@li.org>\n"
+"Plural-Forms: nplurals=6; plural=(((n == 3)) ? 3 : ((n == 6)) ? 4 : ((n "
+"== 1)) ? 1 : ((n == 2)) ? 2 : ((n == 0)) ? 0 : 5)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -166,21 +166,25 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>Gyda %1$s chi sy'n rheoli.</p>\n"
 "<p>Ei ddefnyddio fel porwr preifat:\n"
 "  <ul>\n"
 "    <li>Chwilio a phori o fewn yr ap</li>\n"
-"    <li>Rhwystro tracwyr (neu ddiweddaru'r gosodiadau i ganiatáu tracwyr)</li>\n"
+"    <li>Rhwystro tracwyr (neu ddiweddaru'r gosodiadau i ganiatáu "
+"tracwyr)</li>\n"
 "    <li>Dileu cwcis, yn ogystal â hanes chwilio a phori</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>Mae %1$s wedi ei gynhyrchu gan Mozilla. Ein amcan yw i hybu Rhyngrwyd iach ac agored.<br/>\n"
+"<p>Mae %1$s wedi ei gynhyrchu gan Mozilla. Ein amcan yw i hybu Rhyngrwyd "
+"iach ac agored.<br/>\n"
 "<a href=\"%2$s\">Dysgu rhagor</a></p>"
 
 msgctxt "preference_category_search"
@@ -281,9 +285,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Anfon defnydd data dienw"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Dysgu rhagor"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -319,6 +339,16 @@ msgstr "Dileu'r hanes pori"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Ehangu"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -429,8 +459,12 @@ msgstr "Canfod ap sy'n gallu agor dolen"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "0oes dim o'r apiau ar eich dyfais yn gallu i agor y ddolen. Mae modd gofyn i %1$s chwilio %2$s am ap sy' n gallu gwneud."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"0oes dim o'r apiau ar eich dyfais yn gallu i agor y ddolen. Mae modd "
+"gofyn i %1$s chwilio %2$s am ap sy' n gallu gwneud."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -455,7 +489,9 @@ msgstr "Agor"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Ni fydd ffeiliau sydd wedi eu llwytho i lawr <b>yn cael eu dileu</b> pan fyddwch yn dileu hanes %1$s."
+msgstr ""
+"Ni fydd ffeiliau sydd wedi eu llwytho i lawr <b>yn cael eu dileu</b> pan "
+"fyddwch yn dileu hanes %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -488,13 +524,17 @@ msgstr "Methu cysylltu"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul> \n"
-"        <li>Mae'n bosib fod y wefan yn brysur neu ddim ar gael. Ceisiwch eto cyn bo hir.</li> \n"
-"        <li>Os nad oes modd i chi lwytho unrhyw dudalennau, gwiriwch gysylltiad data neu ddiwifr eich dyfais symudol.</li>\n"
+"        <li>Mae'n bosib fod y wefan yn brysur neu ddim ar gael. Ceisiwch "
+"eto cyn bo hir.</li> \n"
+"        <li>Os nad oes modd i chi lwytho unrhyw dudalennau, gwiriwch "
+"gysylltiad data neu ddiwifr eich dyfais symudol.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -511,14 +551,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Gwiriwch y cyfeiriad am wallau teipio megis\n"
 "          <strong>ww</strong>.example.com yn lle\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Os ydych yn gallu llwytho unrhyw dudalennau, gwiriwch eich dyfais data neu wi-fi cysylltiad.</li>\n"
+"        <li>Os ydych yn gallu llwytho unrhyw dudalennau, gwiriwch eich "
+"dyfais data neu wi-fi cysylltiad.</li>\n"
 "     </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -528,13 +570,17 @@ msgstr "Nid yw'r cyfeiriad yn ddilys"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul> \n"
-"  <li>Fel rheol mae cyfeiriadau Gwe'n cael eu hysgrifennu fel <strong>http://www.example.com/</strong></li>\n"
-"  <li>Gwnewch yn siŵr eich bod yn defnyddio blaen slaes (h.y. <strong>/</strong>).</li> \n"
+"  <li>Fel rheol mae cyfeiriadau Gwe'n cael eu hysgrifennu fel "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Gwnewch yn siŵr eich bod yn defnyddio blaen slaes (h.y. "
+"<strong>/</strong>).</li> \n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -544,11 +590,13 @@ msgstr "Nid yw'r dudalen yn ailgyfeirio'n iawn"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul> \n"
-"  <li>Gall y broblem yma fod wedi ei achosi drwy anablu neu wrthod cwcis.</li> \n"
+"  <li>Gall y broblem yma fod wedi ei achosi drwy anablu neu wrthod "
+"cwcis.</li> \n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -558,11 +606,13 @@ msgstr "Heb ddeall y cyfeiriad"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul> \n"
-"  <li>Efallai bydd angen i chi osod meddalwedd arall i agor y cyfeiriad yma.</li> \n"
+"  <li>Efallai bydd angen i chi osod meddalwedd arall i agor y cyfeiriad "
+"yma.</li> \n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -572,16 +622,20 @@ msgstr "Methodd y cysylltiad diogel"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul> \n"
-"  <li>Gall hwn fod yn anhawster gyda ffurfweddiad y gweinydd neu gall fod \n"
+"  <li>Gall hwn fod yn anhawster gyda ffurfweddiad y gweinydd neu gall fod"
+" \n"
 "yn rhywun sy'n ceisio dynwared y gweinydd.</li> \n"
-"  <li>Os ydych wedi cysylltu'n llwyddiannus gyda'r gweinydd yn y gorffennol, efallai \n"
+"  <li>Os ydych wedi cysylltu'n llwyddiannus gyda'r gweinydd yn y "
+"gorffennol, efallai \n"
 "mai gwall dros dro ydyw ac i geisio eto.</li> \n"
 "</ul>"
 
@@ -627,8 +681,12 @@ msgstr "Agor dolen mewn tab newydd"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Ni fydd delweddau sydd wedi eu cadw a'u rhannu <b>yn cael eu dileu</b> pan fyddwch yn dileu hanes %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Ni fydd delweddau sydd wedi eu cadw a'u rhannu <b>yn cael eu dileu</b> "
+"pan fyddwch yn dileu hanes %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +695,13 @@ msgstr "Cryfhewch eich preifatrwydd"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Cymrwch bori preifat i'r lefel nesaf. Rhwystrwch hysbysebion a chynnwys arall sy'n gallu'ch tracio ar draws wefannau ac arafu amserau llwytho tudalennau."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Cymrwch bori preifat i'r lefel nesaf. Rhwystrwch hysbysebion a chynnwys "
+"arall sy'n gallu'ch tracio ar draws wefannau ac arafu amserau llwytho "
+"tudalennau."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +710,12 @@ msgstr "Chwilio, cynhwysfawr"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Chwilio am rywbeth gwahanol? Dewiswch beiriant chwilio arall yn y Gosodiadau."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Chwilio am rywbeth gwahanol? Dewiswch beiriant chwilio arall yn y "
+"Gosodiadau."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +726,12 @@ msgstr "Ychwanegu llwybrau byr i'ch sgrin cartref"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Ewch i'ch hoff wefannau yn %1$s yn gyflym. Dewiswch \"Ychwanegu i'r Sgrin Cartref\" o ddewislen %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Ewch i'ch hoff wefannau yn %1$s yn gyflym. Dewiswch \"Ychwanegu i'r Sgrin"
+" Cartref\" o ddewislen %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +742,12 @@ msgstr "Arfer preifatrwydd"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Gosodwch %1$s fel eich porwr ragosodedig a derbyn buddiannau pori preifat wrth agor tudalennau gwe mewn apiau eraill."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Gosodwch %1$s fel eich porwr ragosodedig a derbyn buddiannau pori preifat"
+" wrth agor tudalennau gwe mewn apiau eraill."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +785,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Diddymu"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +808,36 @@ msgstr "Agor dolen mewn tab penodol"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Agor"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/da/app.po
+++ b/locales/da/app.po
@@ -1,24 +1,25 @@
-# Translations template for PROJECT.
+# Danish translations for PROJECT.
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-22 08:01+0000\n"
-"Last-Translator: troels.krainer.thomsen <troels.krainer.thomsen@gmail.com>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Last-Translator: troels.krainer.thomsen "
+"<troels.krainer.thomsen@gmail.com>\n"
 "Language: da\n"
+"Language-Team: da <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 1)) || ((!((0 == 0))) && ((n =="
+" 0) || (n == 1)))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -166,10 +167,12 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 
@@ -271,9 +274,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Send anonyme brugsdata"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Læs mere"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -309,6 +328,16 @@ msgstr ""
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Udvid"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -419,8 +448,12 @@ msgstr "Find en app der kan åbne linket"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ingen app på din enhed kan åbne dette link. Du kan forlade %1$s og søge på %2$s efter en app der kan."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ingen app på din enhed kan åbne dette link. Du kan forlade %1$s og søge "
+"på %2$s efter en app der kan."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -478,8 +511,10 @@ msgstr "Ude af stand til at oprette forbindelse"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 
@@ -497,7 +532,8 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 
@@ -508,8 +544,10 @@ msgstr "Adressen er ikke gyldig"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 
@@ -520,7 +558,8 @@ msgstr "Denne side viderefører ikke forespørgslen korrekt"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 
@@ -531,11 +570,13 @@ msgstr "Adressen kunne ikke forstås"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Du er måske nødt til at installere andet software for at åbne denne adresse.</li>\n"
+"  <li>Du er måske nødt til at installere andet software for at åbne denne"
+" adresse.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -545,9 +586,11 @@ msgstr "Sikker forbindelse mislykkedes"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
@@ -594,7 +637,9 @@ msgstr "Åbn link i nyt faneblad"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
 msgstr ""
 
 #. First run tour (Default browser): Title
@@ -604,7 +649,9 @@ msgstr ""
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
 msgstr ""
 
 #. First run tour (Search): Title
@@ -614,7 +661,9 @@ msgstr ""
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr ""
 
 #. First run tour (Shortcut): Title
@@ -626,7 +675,9 @@ msgstr "Tilføj genveje til din startskærm"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
 msgstr ""
 
 #. First run tour (Privacy): Title
@@ -638,7 +689,9 @@ msgstr ""
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
 msgstr ""
 
 msgctxt "firstrun_close_button"
@@ -677,6 +730,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Annuller"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -692,3 +753,36 @@ msgstr ""
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Åbn"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/de/app.po
+++ b/locales/de/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 17:39+0000\n"
 "Last-Translator: Michael Köhler <michael.koehler1@gmx.de>\n"
-"Language-Team: de <LL@li.org>\n"
 "Language: de\n"
+"Language-Team: de <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 1)) && ((0 == 0))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s gibt Ihnen die Kontrolle.</p>\n"
 "<p>Verwenden Sie es als privaten Browser:\n"
 "  <ul>\n"
 "    <li>Suchen und blättern Sie in der App</li>\n"
-"    <li>Blockieren Sie Tracker (oder aktualisieren Sie die Einstellungen, um Tracker zu erlauben)</li>\n"
-"    <li>Entfernen Sie Cookies, um Such- und Browserverlauf zu löschen</li>\n"
+"    <li>Blockieren Sie Tracker (oder aktualisieren Sie die Einstellungen,"
+" um Tracker zu erlauben)</li>\n"
+"    <li>Entfernen Sie Cookies, um Such- und Browserverlauf zu "
+"löschen</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s wird von Mozilla entwickelt. Unsere Mission ist es, ein gesundes, offenes Internet zu fördern.<br/>\n"
+"<p>%1$s wird von Mozilla entwickelt. Unsere Mission ist es, ein gesundes,"
+" offenes Internet zu fördern.<br/>\n"
 "<a href=\"%2$s\">Erfahren Sie mehr</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Anonyme Nutzungsdaten senden"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Mehr erfahren"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Browser-Chronik löschen"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Ausklappen"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "App zum Öffnen des Links finden"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Anscheinend kann keine der Apps auf Ihrem Gerät diesen Link öffnen. Sie können %1$s verlassen und bei %2$s nach einer App dafür suchen."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Anscheinend kann keine der Apps auf Ihrem Gerät diesen Link öffnen. Sie "
+"können %1$s verlassen und bei %2$s nach einer App dafür suchen."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +491,9 @@ msgstr "Öffnen"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Heruntergeladene Dateien werden beim Löschen der Chronik von %1$s <b>nicht gelöscht</b>."
+msgstr ""
+"Heruntergeladene Dateien werden beim Löschen der Chronik von %1$s "
+"<b>nicht gelöscht</b>."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +526,17 @@ msgstr "Verbindung fehlgeschlagen"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Die Website könnte vorübergehend nicht erreichbar sein, versuchen Sie es bitte später nochmals.</li>\n"
-"        <li>Wenn Sie auch keine andere Website aufrufen können, überprüfen Sie bitte die Daten- oder WLAN-Verbindung. </li>\n"
+"        <li>Die Website könnte vorübergehend nicht erreichbar sein, "
+"versuchen Sie es bitte später nochmals.</li>\n"
+"        <li>Wenn Sie auch keine andere Website aufrufen können, "
+"überprüfen Sie bitte die Daten- oder WLAN-Verbindung. </li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +553,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Bitte überprüfen Sie die Adresse auf Tippfehler, wie\n"
 "          <strong>ww</strong>.example.com statt\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Wenn Sie auch keine andere Website aufrufen können, überprüfen Sie bitte die Daten- oder WLAN-Verbindung. </li>\n"
+"        <li>Wenn Sie auch keine andere Website aufrufen können, "
+"überprüfen Sie bitte die Daten- oder WLAN-Verbindung. </li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +572,17 @@ msgstr "Fehler: Ungültige Adresse"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Web-Adressen sehen für gewöhnlich folgendermaßen aus: <strong>http://www.example.com/</strong></li>\n"
-"  <li>Bitte stellen Sie sicher, dass Sie nicht den umgekehrten, sondern den einfachen Schrägstrich verwenden (<strong>/</strong>).</li>\n"
+"  <li>Web-Adressen sehen für gewöhnlich folgendermaßen aus: "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Bitte stellen Sie sicher, dass Sie nicht den umgekehrten, sondern "
+"den einfachen Schrägstrich verwenden (<strong>/</strong>).</li>\n"
 " </ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +592,13 @@ msgstr "Fehler: Umleitungsfehler"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Dieses Problem kann manchmal auftreten, wenn Cookies deaktiviert oder abgelehnt werden.</li> \n"
+"  <li>Dieses Problem kann manchmal auftreten, wenn Cookies deaktiviert "
+"oder abgelehnt werden.</li> \n"
 " </ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +608,13 @@ msgstr "Adresse nicht erkannt"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Eventuell müssen Sie andere Software installieren, um diese Adresse aufrufen zu können.</li>\n"
+"  <li>Eventuell müssen Sie andere Software installieren, um diese Adresse"
+" aufrufen zu können.</li>\n"
 " </ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +624,20 @@ msgstr "Fehler: Gesicherte Verbindung fehlgeschlagen"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Das könnte ein Problem mit der Konfiguration des Servers sein, oder jemand will sich als dieser Server ausgeben.</li>\n"
-"  <li>Wenn Sie mit diesem Server in der Vergangenheit erfolgreich Verbindungen herstellen konnten, ist der Fehler eventuell nur vorübergehend, und Sie können es später erneut versuchen.</li>\n"
+"  <li>Das könnte ein Problem mit der Konfiguration des Servers sein, oder"
+" jemand will sich als dieser Server ausgeben.</li>\n"
+"  <li>Wenn Sie mit diesem Server in der Vergangenheit erfolgreich "
+"Verbindungen herstellen konnten, ist der Fehler eventuell nur "
+"vorübergehend, und Sie können es später erneut versuchen.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +682,12 @@ msgstr "Link in neuem Tab öffnen"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Gespeicherte und geteilte Grafiken <b>werden nicht gelöscht</b>, wenn Sie die Chronik von %1$s löschen."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Gespeicherte und geteilte Grafiken <b>werden nicht gelöscht</b>, wenn Sie"
+" die Chronik von %1$s löschen."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +696,13 @@ msgstr "Stärken Sie Ihre Privatsphäre"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Privates Surfen auf einer höheren Stufe. Blockieren Sie Werbung und andere Inhalte, die Sie über Websites hinweg verfolgen können und Seitenladezeiten verlängern."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Privates Surfen auf einer höheren Stufe. Blockieren Sie Werbung und "
+"andere Inhalte, die Sie über Websites hinweg verfolgen können und "
+"Seitenladezeiten verlängern."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +711,12 @@ msgstr "Ihre Suche, wie Sie möchten"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Suchen Sie etwas anderes? Wählen Sie in den Einstellungen eine andere Standardsuchmaschine."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Suchen Sie etwas anderes? Wählen Sie in den Einstellungen eine andere "
+"Standardsuchmaschine."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +727,12 @@ msgstr "Fügen Sie Verknüpfungen auf Ihrem Startbildschirm hinzu"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Kehren Sie schnell zu Ihren Lieblings-Websites in %1$s zurück. Wählen Sie einfach im %1$s-Menü „Zum Startbildschirm hinzufügen“."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Kehren Sie schnell zu Ihren Lieblings-Websites in %1$s zurück. Wählen Sie"
+" einfach im %1$s-Menü „Zum Startbildschirm hinzufügen“."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +743,12 @@ msgstr "Machen Sie Privatsphäre zur Gewohnheit"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Verwenden Sie %1$s als Standardbrowser und nutzen Sie die Vorteile des privaten Surfens, wenn Sie aus anderen Apps Webseiten öffnen."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Verwenden Sie %1$s als Standardbrowser und nutzen Sie die Vorteile des "
+"privaten Surfens, wenn Sie aus anderen Apps Webseiten öffnen."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +786,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Abbrechen"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +809,36 @@ msgstr "Link in gewähltem Tab öffnen"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Öffnen"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/dsb/app.po
+++ b/locales/dsb/app.po
@@ -6,17 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 20:25+0000\n"
 "Last-Translator: Michael Wolf <milupo@sorbzilla.de>\n"
-"Language-Team: dsb <LL@li.org>\n"
 "Language: dsb\n"
+"Language-Team: dsb <LL@li.org>\n"
+"Plural-Forms: nplurals=4; plural=(((((0 == 0)) && (((n % 100) >= 3 && (n "
+"% 100) <= 4))) || (((0 % 100) >= 3 && (0 % 100) <= 4))) ? 2 : ((((0 == "
+"0)) && (((n % 100) == 1))) || (((0 % 100) == 1))) ? 0 : ((((0 == 0)) && "
+"(((n % 100) == 2))) || (((0 % 100) == 2))) ? 1 : 3)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -166,21 +168,25 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s dajo was kontrolu wobchowaś.</p>\n"
 "<p>Wužywajśo jen ako priwatny wobglědowak:\n"
 "  <ul>\n"
 "    <li>Pytajśo a pśeglědujśo direktnje w nałoženju</li>\n"
-"    <li>Blokěrujśo pśeslědowaki (abo aktualizěrujśo nastajenja, aby pśeslědowaki dowólił)</li>\n"
+"    <li>Blokěrujśo pśeslědowaki (abo aktualizěrujśo nastajenja, aby "
+"pśeslědowaki dowólił)</li>\n"
 "    <li>Lašujśo cookieje a pytańsku a pśeglědowańsku historiju</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s se wót Mozilla wuwija. Naša misija jo spěchowanje strowego, wótwórjonego interneta.<br/>\n"
+"<p>%1$s se wót Mozilla wuwija. Naša misija jo spěchowanje strowego, "
+"wótwórjonego interneta.<br/>\n"
 "<a href=\"%2$s\">Dalšne informacije</a></p>"
 
 msgctxt "preference_category_search"
@@ -281,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Anonymne wužywańske daty pósłaś"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Dalšne informacije"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -319,6 +341,16 @@ msgstr "Pśeglědowańsku historiju lašowaś"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Pokazaś"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -429,8 +461,12 @@ msgstr "Nałoženje pytaś, kótarež móžo wótkaz wócyniś"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Žedno z nałoženjow na wašom rěźe njamóžo toś ten wótkaz wócyniś. Móžośo %1$s spušćiś, aby %2$s za nałoženim pśepytował."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Žedno z nałoženjow na wašom rěźe njamóžo toś ten wótkaz wócyniś. Móžośo "
+"%1$s spušćiś, aby %2$s za nałoženim pśepytował."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -488,13 +524,17 @@ msgstr "Žeden zwisk móžny"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Sedło njestoj snaź nachylu k dispoziciji abo jo pśeśěžone. Wopytajśo za mało wokognuśow hyšći raz.</li>\n"
-"        <li>Jolic njamóžośo boki zacytaś, pśeglědajśo datowy abo WLAN-zwisk wašogo mobilnego rěda.</li>\n"
+"        <li>Sedło njestoj snaź nachylu k dispoziciji abo jo pśeśěžone. "
+"Wopytajśo za mało wokognuśow hyšći raz.</li>\n"
+"        <li>Jolic njamóžośo boki zacytaś, pśeglědajśo datowy abo WLAN-"
+"zwisk wašogo mobilnego rěda.</li>\n"
 "        </ul>"
 
 msgctxt "error_timeout_title"
@@ -511,14 +551,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Pśeglědajśo adresu za pisańskimi zmólkami ako\n"
 "          <strong>ww</strong>.example.com město\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Jolic njamóžośo boki zacytaś, pśeglědajśo daty swójogo rěda abo swój WLAN-zwisk.</li>\n"
+"        <li>Jolic njamóžośo boki zacytaś, pśeglědajśo daty swójogo rěda "
+"abo swój WLAN-zwisk.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -528,13 +570,17 @@ msgstr "Adresa njejo płaśiwa"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Webadrese se zwětšego ako <strong>http://www.example.com/</strong> pišu.</li>\n"
-"  <li>Zawěsććo, až wužywaśo doprědka schylone nakósne smužki (t. gr. <strong>/</strong>).</li>\n"
+"  <li>Webadrese se zwětšego ako <strong>http://www.example.com/</strong> "
+"pišu.</li>\n"
+"  <li>Zawěsććo, až wužywaśo doprědka schylone nakósne smužki (t. gr. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -544,11 +590,13 @@ msgstr "Bok pšawje njepósrědnja"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Toś ten problem zawinujo se wótergi pśez zmóžnjanje abo znjemóžnjanje ookiejow.</li>\n"
+"  <li>Toś ten problem zawinujo se wótergi pśez zmóžnjanje abo "
+"znjemóžnjanje ookiejow.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -558,11 +606,13 @@ msgstr "Adresa njejo se zrozměła"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Musyśo snaź druge programy instalěrowaś, aby se toś ta adresa wócyniła.</li>\n"
+"  <li>Musyśo snaź druge programy instalěrowaś, aby se toś ta adresa "
+"wócyniła.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -572,16 +622,19 @@ msgstr "Wěsty zwisk njejo móžny"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
 "  <li>To by mógło problem z konfiguraciju serwera byś, abo by mógło byś,\n"
 "až něchten wopytujo serwer imitěrowaś.</li>\n"
-"  <li>Jolic sćo był ze serwerom w zachadnosći wuspěšnje zwězany, by mógła zmólka snaź\n"
+"  <li>Jolic sćo był ze serwerom w zachadnosći wuspěšnje zwězany, by mógła"
+" zmólka snaź\n"
 "nachylna byś a móžośo pózdźej hyšći raz wopytaś.</li>\n"
 "</ul>"
 
@@ -627,8 +680,12 @@ msgstr "Wótkaz w nowem rejtarku wócyniś"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Skłaźone a źělone wobraze <b>se njewulašuju</b>, gaž historiju %1$s lašujośo."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Skłaźone a źělone wobraze <b>se njewulašuju</b>, gaž historiju %1$s "
+"lašujośo."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +694,13 @@ msgstr "Zmocniśo swóju priwatnosć"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Zwigniśo priwatne pśeglědowanje na pśiducu wušu rowninu. Blokěrujśo wabjenje a hynakše wopśimjeśe, kótarež móžośo pśez sedła slědowaś a zacyitańske case bokow pódlejšyś."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Zwigniśo priwatne pśeglědowanje na pśiducu wušu rowninu. Blokěrujśo "
+"wabjenje a hynakše wopśimjeśe, kótarež móžośo pśez sedła slědowaś a "
+"zacyitańske case bokow pódlejšyś."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,7 +709,9 @@ msgstr "Wašo pytanje ako wy jo cośo"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "Pytaśo za něcym drugim? Wubjeŕśo drugu standardnu pytnicu w nastajenjach."
 
 #. First run tour (Shortcut): Title
@@ -659,8 +723,12 @@ msgstr "Pśidajśo swójej startowej wobrazowce tastowe skrotconki"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Wrośćo se malsnjej k swójim nejlubšym sedłam w %1$s. Wubjeŕśo jadnorje „Startowej wobrazowce pśidaś“ z menija %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Wrośćo se malsnjej k swójim nejlubšym sedłam w %1$s. Wubjeŕśo jadnorje "
+"„Startowej wobrazowce pśidaś“ z menija %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +739,12 @@ msgstr "Pśiwucćo se priwatnosć"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Nastajśo %1$s ako swój standardny wobglědowak a mějśo wužytk z priwatnego pśeglědowanja, gaž webboki z drugich nałoženjow wócynjaśo."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Nastajśo %1$s ako swój standardny wobglědowak a mějśo wužytk z priwatnego"
+" pśeglědowanja, gaž webboki z drugich nałoženjow wócynjaśo."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +782,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Pśetergnuś"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +805,36 @@ msgstr "Wótkaz we wubranem rejtarku wócyniś"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Wócyniś"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/el/app.po
+++ b/locales/el/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-26 09:09+0000\n"
 "Last-Translator: Jim Spentzos <jamesspentzos@hotmail.com>\n"
-"Language-Team: el <LL@li.org>\n"
 "Language: el\n"
+"Language-Team: el <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>Το %1$s σάς δίνει τον έλεγχο.</p>\n"
 "<p>Χρησιμοποιήστε το ως πρόγραμμα ιδιωτικής περιήγησης:\n"
 "  <ul>\n"
 "    <li>Αναζητήστε και περιηγηθείτε εντός της εφαρμογής</li>\n"
-"    <li>Αποκλείστε trackers (ή ενημερώστε τις ρυθμίσεις σας ώστε να επιτρέπονται)</li>\n"
-"    <li>Διαγράψτε τα cookies, καθώς και το ιστορικό αναζητήσεων και περιήγησης</li>\n"
+"    <li>Αποκλείστε trackers (ή ενημερώστε τις ρυθμίσεις σας ώστε να "
+"επιτρέπονται)</li>\n"
+"    <li>Διαγράψτε τα cookies, καθώς και το ιστορικό αναζητήσεων και "
+"περιήγησης</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>Το %1$s δημιουργήθηκε από τη Mozilla. Η αποστολή μας είναι να προαγάγουμε ένα υγιές, ανοιχτό διαδίκτυο.<br/>\n"
+"<p>Το %1$s δημιουργήθηκε από τη Mozilla. Η αποστολή μας είναι να "
+"προαγάγουμε ένα υγιές, ανοιχτό διαδίκτυο.<br/>\n"
 "<a href=\"%2$s\">Μάθετε περισσότερα</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Αποστολή ανώνυμων δεδομένων χρήσης"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Μάθετε περισσότερα"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Διαγραφή ιστορικού περιήγησης"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Επέκταση"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,10 +461,13 @@ msgstr "Βρείτε μια εφαρμογή που μπορεί να ανοίξ
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
 msgstr ""
-"Καμία από τις εφαρμογές της συσκευής σας δεν μπορεί να ανοίξει αυτό το σύνδεσμο. Μπορείτε να αποχωρήσετε από το %1$s για να αναζητήσετε στο %2$s μια εφαρμογή που να μπορεί να εκτελέσει αυτή την "
-"εργασία."
+"Καμία από τις εφαρμογές της συσκευής σας δεν μπορεί να ανοίξει αυτό το "
+"σύνδεσμο. Μπορείτε να αποχωρήσετε από το %1$s για να αναζητήσετε στο %2$s"
+" μια εφαρμογή που να μπορεί να εκτελέσει αυτή την εργασία."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -459,7 +492,9 @@ msgstr "Άνοιγμα"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Τα ληφθέντα αρχεία <b>δεν θα διαγραφούν</b> όταν σβήσετε το %1$s ιστορικό σας."
+msgstr ""
+"Τα ληφθέντα αρχεία <b>δεν θα διαγραφούν</b> όταν σβήσετε το %1$s ιστορικό"
+" σας."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -492,13 +527,17 @@ msgstr "Αδυναμία σύνδεσης"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Η ιστοσελίδα θα μπορούσε να είναι προσωρινώς μη διαθέσιμη ή πολύ απασχολημένη. Δοκιμάστε ξανά σε λίγο.</li>\n"
-"        <li>Αν δεν μπορείτε να φορτώσετε καμία σελίδα, ελέγξτε τα δεδομένα κινητής ή τη σύνδεση Wi-Fi σας.</li>\n"
+"        <li>Η ιστοσελίδα θα μπορούσε να είναι προσωρινώς μη διαθέσιμη ή "
+"πολύ απασχολημένη. Δοκιμάστε ξανά σε λίγο.</li>\n"
+"        <li>Αν δεν μπορείτε να φορτώσετε καμία σελίδα, ελέγξτε τα "
+"δεδομένα κινητής ή τη σύνδεση Wi-Fi σας.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -515,14 +554,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Ελέγξτε τη διεύθυνση για ορθογραφικά λάθη όπως\n"
 "          <strong>ww</strong>.example.com αντί για\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Αν δεν μπορείτε να φορτώσετε καμία σελίδα, ελέγξτε τα δεδομένα κινητής ή τη σύνδεση Wi-Fi σας.</li>\n"
+"        <li>Αν δεν μπορείτε να φορτώσετε καμία σελίδα, ελέγξτε τα "
+"δεδομένα κινητής ή τη σύνδεση Wi-Fi σας.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -532,13 +573,17 @@ msgstr "Η διεύθυνση δεν είναι έγκυρη"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Οι διαδικτυακές διευθύνσεις γράφονται συνήθως έτσι: <strong>http://www.example.com/</strong></li>\n"
-"  <li>Βεβαιωθείτε ότι χρησιμοποιείτε κάθετο (i.e. <strong>/</strong>).</li>\n"
+"  <li>Οι διαδικτυακές διευθύνσεις γράφονται συνήθως έτσι: "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Βεβαιωθείτε ότι χρησιμοποιείτε κάθετο (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -548,11 +593,13 @@ msgstr "Η σελίδα δεν ανακατευθύνεται κανονικά"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Αυτό το πρόβλημα μπορεί μερικές φορές να προκληθεί από την απενεργοποίηση ή την άρνηση για αποδοχή των cookies.</li>\n"
+"  <li>Αυτό το πρόβλημα μπορεί μερικές φορές να προκληθεί από την "
+"απενεργοποίηση ή την άρνηση για αποδοχή των cookies.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -562,11 +609,13 @@ msgstr "Η διεύθυνση δεν ήταν κατανοητή"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Ενδέχεται να χρειαστεί να εγκαταστήσετε άλλο λογισμικό για να ανοίξετε αυτή τη διεύθυνση.</li>\n"
+"  <li>Ενδέχεται να χρειαστεί να εγκαταστήσετε άλλο λογισμικό για να "
+"ανοίξετε αυτή τη διεύθυνση.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -576,16 +625,20 @@ msgstr "Αποτυχία ασφαλούς σύνδεσης"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Αυτό θα μπορούσε να είναι πρόβλημα με τη ρύθμιση του διακομιστή, ή θα μπορούσε να είναι\n"
+"  <li>Αυτό θα μπορούσε να είναι πρόβλημα με τη ρύθμιση του διακομιστή, ή "
+"θα μπορούσε να είναι\n"
 "κάποιος που προσπαθεί να μιμηθεί το διακομιστή.</li>\n"
-"  <li>Αν έχετε συνδεθεί σε αυτό το διακομιστή επιτυχώς στο παρελθόν, το σφάλμα ενδέχεται να\n"
+"  <li>Αν έχετε συνδεθεί σε αυτό το διακομιστή επιτυχώς στο παρελθόν, το "
+"σφάλμα ενδέχεται να\n"
 "είναι προσωρινό και μπορείτε να δοκιμάσετε ξανά αργότερα.</li>\n"
 "</ul>"
 
@@ -631,8 +684,12 @@ msgstr ""
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Οι αποθηκευμένες και κοινόχρηστες εικόνες <b>δεν θα διαγραφούν</b> όταν διαγράψετε το ιστορικού του %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Οι αποθηκευμένες και κοινόχρηστες εικόνες <b>δεν θα διαγραφούν</b> όταν "
+"διαγράψετε το ιστορικού του %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -641,7 +698,9 @@ msgstr "Ενισχύστε το απόρρητό σας"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
 msgstr ""
 
 #. First run tour (Search): Title
@@ -651,7 +710,9 @@ msgstr ""
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr ""
 
 #. First run tour (Shortcut): Title
@@ -663,7 +724,9 @@ msgstr ""
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
 msgstr ""
 
 #. First run tour (Privacy): Title
@@ -675,7 +738,9 @@ msgstr ""
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
 msgstr ""
 
 msgctxt "firstrun_close_button"
@@ -714,6 +779,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Ακύρωση"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -729,3 +802,36 @@ msgstr "Άνοιγμα συνδέσμου σε επιλεγμένη καρτέλ
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Άνοιγμα"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/eo/app.po
+++ b/locales/eo/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-22 16:30+0000\n"
 "Last-Translator: eduardo <eduardo@esperanto.org.uy>\n"
-"Language-Team: eo <LL@li.org>\n"
 "Language: eo\n"
+"Language-Team: eo <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,10 +167,12 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s igas vin reganto.</p>\n"
@@ -182,7 +183,8 @@ msgstr ""
 "    <li>Forigi kuketojn kaj ankaŭ retuman kaj serĉan historion</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s estas farita de Mozilla. Nia misio estas stimuli sanan kaj malfermitan interreton.<br/>\n"
+"<p>%1$s estas farita de Mozilla. Nia misio estas stimuli sanan kaj "
+"malfermitan interreton.<br/>\n"
 "<a href=\"%2$s\">Pli da informo</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +285,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Sendi anonimajn datumojn pri uzo"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Pli da informo"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +339,16 @@ msgstr "Viŝi retuman historion"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Malfaldi"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +459,12 @@ msgstr "Serĉi programon, kiu povas malfermi ligilon"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Neniu programo en via aparato povas malfermi tiun ĉi ligilon. Vi povas forlasi %1$s por serĉi en %2$s programon kiu povas fari tion."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Neniu programo en via aparato povas malfermi tiun ĉi ligilon. Vi povas "
+"forlasi %1$s por serĉi en %2$s programon kiu povas fari tion."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +489,9 @@ msgstr "Malfermi"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Elŝutitaj dosieroj <b>ne estos forigitaj</b> kiam vi viŝas la historion de %1$s."
+msgstr ""
+"Elŝutitaj dosieroj <b>ne estos forigitaj</b> kiam vi viŝas la historion "
+"de %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +524,17 @@ msgstr "Ne eblas konekti"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>La retejo povas esti nuntempe ne alirebla, aŭ tro okupata. Bonvolu klopodi denove post iom da tempo.</li>\n"
-"        <li>Se vi ne povas malfermi iun ajn paĝon, kontrolu la datuman aŭ sendratan konekton de via poŝaparato.</li>\n"
+"        <li>La retejo povas esti nuntempe ne alirebla, aŭ tro okupata. "
+"Bonvolu klopodi denove post iom da tempo.</li>\n"
+"        <li>Se vi ne povas malfermi iun ajn paĝon, kontrolu la datuman aŭ"
+" sendratan konekton de via poŝaparato.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +551,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Kontrolu en la literumo de la adreso ke ne estu eraroj kiel\n"
 "          <strong>ww</strong>.example.com anstataŭ\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Se vi ne povas malfermi iun ajn paĝon , kontrolu la datuman aŭ sendratan konekton de via aparato.</li>\n"
+"        <li>Se vi ne povas malfermi iun ajn paĝon , kontrolu la datuman "
+"aŭ sendratan konekton de via aparato.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +570,17 @@ msgstr "La adreso ne estas valida"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Retadresoj estas kutime ĉi tiel skribitaj <strong>http://www.example.com/</strong></li>\n"
-"  <li>Estu certa uzi la ĝustajn oblikvajn strekojn (i.e. <strong>/</strong>).</li>\n"
+"  <li>Retadresoj estas kutime ĉi tiel skribitaj "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Estu certa uzi la ĝustajn oblikvajn strekojn (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +590,13 @@ msgstr "La paĝo malbone redirektas"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Tio povas okazi kelkfoje kiam oni malebligas aŭ rifuzas kuketojn.</li>\n"
+"  <li>Tio povas okazi kelkfoje kiam oni malebligas aŭ rifuzas "
+"kuketojn.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +606,13 @@ msgstr "La adreso ne estis komprenita"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Vi eble bezonas instali alian programon por povi malfermi tiun ĉi adreson.</li>\n"
+"  <li>Vi eble bezonas instali alian programon por povi malfermi tiun ĉi "
+"adreson.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +622,19 @@ msgstr "Malsukcesa sekura konekto"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Tio povus esti problemo kun la agordoj de la servilo, aŭ iu kiu klopodas trompe ŝajnigi esti tiu servilo.</li>\n"
-"  <li>Se vi konektiĝis al tiu servilo en la pasinto, la eraro povas esti momenta, kaj vi povos klopodi denove poste.</li>\n"
+"  <li>Tio povus esti problemo kun la agordoj de la servilo, aŭ iu kiu "
+"klopodas trompe ŝajnigi esti tiu servilo.</li>\n"
+"  <li>Se vi konektiĝis al tiu servilo en la pasinto, la eraro povas esti "
+"momenta, kaj vi povos klopodi denove poste.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +679,12 @@ msgstr "Malfermi ligilon en nova langeto"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Konservitaj kaj dividitaj bildoj <b>ne estos forigitaj</b> kiam vi viŝas la historion de %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Konservitaj kaj dividitaj bildoj <b>ne estos forigitaj</b> kiam vi viŝas "
+"la historion de %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +693,12 @@ msgstr "Plibonigi vian privatecon"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Privata retumo pli altnivela, kun blokado de reklamoj kaj aliaj enhavoj, kiuj povas spuri vin trans retejoj kaj malrapidigi la ŝargon de paĝoj."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Privata retumo pli altnivela, kun blokado de reklamoj kaj aliaj enhavoj, "
+"kiuj povas spuri vin trans retejoj kaj malrapidigi la ŝargon de paĝoj."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +707,12 @@ msgstr "Via serĉo laŭ via maniero"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Ĉu vi serĉas ion alian, malsaman? Elektu alian norman serĉilon en la agordoj."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Ĉu vi serĉas ion alian, malsaman? Elektu alian norman serĉilon en la "
+"agordoj."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +723,12 @@ msgstr "Aldoni rektajn alirojn al via hejmekrano"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "En %1$s, por reiri rapide al viaj plej ŝatataj retejoj, elektu \"Aldoni al hejmekrano\" en la menuo."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"En %1$s, por reiri rapide al viaj plej ŝatataj retejoj, elektu \"Aldoni "
+"al hejmekrano\" en la menuo."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +739,12 @@ msgstr "Alkutimiĝu al la privateco"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Elektu %1$s kiel via normal retumilo kaj ricevu ĉiujn avantaĝojn de la privata retumo, kiam vi malfermas paĝojn el aliaj programoj."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Elektu %1$s kiel via normal retumilo kaj ricevu ĉiujn avantaĝojn de la "
+"privata retumo, kiam vi malfermas paĝojn el aliaj programoj."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +782,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Nuligi"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +805,36 @@ msgstr "Malfermi ligilon en elektita langeto"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Malfermi"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/es-AR/app.po
+++ b/locales/es-AR/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-20 16:58+0000\n"
 "Last-Translator: Marcelo Poli <enzomatrix@gmail.com>\n"
-"Language-Team: es_AR <LL@li.org>\n"
 "Language: es_AR\n"
+"Language-Team: es_AR <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s te da el control.</p>\n"
 "<p>Usalo como un navegador privado:\n"
 "  <ul>\n"
 "    <li>Buscar y navegar en la aplicación</li>\n"
-"    <li>Bloquear rastreadores (o actualizar opciones para permitir rastreadores)</li>\n"
-"    <li>Borrar para eliminar cookies e historial de búsqueda y navegación</li>\n"
+"    <li>Bloquear rastreadores (o actualizar opciones para permitir "
+"rastreadores)</li>\n"
+"    <li>Borrar para eliminar cookies e historial de búsqueda y "
+"navegación</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s es producido por Mozilla. Nuestra misión es promover una internet abierta y saludable.<br/>\n"
+"<p>%1$s es producido por Mozilla. Nuestra misión es promover una internet"
+" abierta y saludable.<br/>\n"
 "<a href=\"%2$s\">Conocer más</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Enviar datos de uso anónimos"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Conocer más"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Limpiar historial de navegación"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Expandir"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "Buscar una app que pueda abrir el enlace"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ninguna de las apps en el dispositivo puede abrir este enlace. Podés dejar que %1$s busque en %2$s una app que pueda."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ninguna de las apps en el dispositivo puede abrir este enlace. Podés "
+"dejar que %1$s busque en %2$s una app que pueda."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +491,9 @@ msgstr "Abrir"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Los archivos descargados <b>no serán eliminados</b> al borrar el historial de %1$s."
+msgstr ""
+"Los archivos descargados <b>no serán eliminados</b> al borrar el "
+"historial de %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +526,17 @@ msgstr "No se puede conectar"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>El sitio puede estar temporariamente inaccesible o demasiado ocupado. Intentá nuevamente en unos momentos.</li>\n"
-"        <li>Si no podés cargar ninguna página, verificá la conexión de datos o Wi-Fi de tu dispositivo.</li>\n"
+"        <li>El sitio puede estar temporariamente inaccesible o demasiado "
+"ocupado. Intentá nuevamente en unos momentos.</li>\n"
+"        <li>Si no podés cargar ninguna página, verificá la conexión de "
+"datos o Wi-Fi de tu dispositivo.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +553,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Fijate si la dirección no tiene errores de tipeo como\n"
 "          <strong>ww</strong>.example.com en vez de\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Si no podés cargar ninguna página, verificá la conexión de datos o Wi-Fi de tu dispositivo.</li>\n"
+"        <li>Si no podés cargar ninguna página, verificá la conexión de "
+"datos o Wi-Fi de tu dispositivo.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +572,17 @@ msgstr "La dirección no es válida"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Las direcciones web normalmente se escriben como <strong>http://www.example.com/</strong></li>\n"
-"  <li>Asegurate de usar las barras correctas (ej. <strong>/</strong>).</li>\n"
+"  <li>Las direcciones web normalmente se escriben como "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Asegurate de usar las barras correctas (ej. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +592,13 @@ msgstr "La página no está siendo redireccionada correctamente"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Este problema puede estar causado a veces por deshabilitar o rechazar cookies.</li>\n"
+"  <li>Este problema puede estar causado a veces por deshabilitar o "
+"rechazar cookies.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,7 +608,8 @@ msgstr "La dirección no fue comprendida"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -574,16 +623,20 @@ msgstr "Fallo en conexión segura"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Podría haber un problema con la configuración del servidor o podría ser\n"
+"  <li>Podría haber un problema con la configuración del servidor o podría"
+" ser\n"
 "alguien tratando de hacerse pasar por ese servidor.</li>\n"
-"  <li>Si te conectaste exitosamente a este servidor en el pasado, el error puede\n"
+"  <li>Si te conectaste exitosamente a este servidor en el pasado, el "
+"error puede\n"
 "ser temporal y podés probar más tarde.</li>\n"
 "</ul>"
 
@@ -629,8 +682,12 @@ msgstr "Abrir enlace en nueva pestaña"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "La imágenes que guardaste y compartiste <b>no serán borradas</b> cuando borres el historial de %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"La imágenes que guardaste y compartiste <b>no serán borradas</b> cuando "
+"borres el historial de %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -639,8 +696,13 @@ msgstr "Potenciá tu privacidad"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Llevá la navegación privada al siguiente nivel. Bloqueá publicidades y otro contenido que puede reastrearte en todos los sitios y empantanar los tiempos de carga de las páginas."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Llevá la navegación privada al siguiente nivel. Bloqueá publicidades y "
+"otro contenido que puede reastrearte en todos los sitios y empantanar los"
+" tiempos de carga de las páginas."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -649,8 +711,12 @@ msgstr "Tu búsqueda, tu manera"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "¿Buscás algo diferente? Elegí otro buscador predeterminado en la configuración."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"¿Buscás algo diferente? Elegí otro buscador predeterminado en la "
+"configuración."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -661,8 +727,12 @@ msgstr "Agregar accesos directos a la pantalla principal"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Volvé a tus sitios favoritos en %1$s rápidamente. Seleccioná \"Agregar a pantalla de inicio\" en el menú de %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Volvé a tus sitios favoritos en %1$s rápidamente. Seleccioná \"Agregar a "
+"pantalla de inicio\" en el menú de %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -673,8 +743,13 @@ msgstr "Hacé de la privacidad un hábito"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Establecé %1$s como tu navegador predeterminado y obtené los beneficios de la navegación privada cuando abrís páginas web desde otras aplicaciones."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Establecé %1$s como tu navegador predeterminado y obtené los beneficios "
+"de la navegación privada cuando abrís páginas web desde otras "
+"aplicaciones."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -712,6 +787,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Cancelar"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -727,3 +810,36 @@ msgstr "Abrir enlace en una pestaña seleccionada"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Abrir"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/es-CL/app.po
+++ b/locales/es-CL/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-19 19:25+0000\n"
 "Last-Translator: saeed <saeed@ravmn.cl>\n"
-"Language-Team: es_CL <LL@li.org>\n"
 "Language: es_CL\n"
+"Language-Team: es_CL <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s te pone al control.</p>\n"
 "<p>Úsalo como un navegador privado:\n"
 "  <ul>\n"
 "    <li>Busca y navega directo desde la app</li>\n"
-"    <li>Bloquea rastreadores (o cambia los ajustes para permitirlos)</li>\n"
-"    <li>Mantente libre de cookies y del historial de búsqueda y navegación</li>\n"
+"    <li>Bloquea rastreadores (o cambia los ajustes para permitirlos)</li>"
+"\n"
+"    <li>Mantente libre de cookies y del historial de búsqueda y "
+"navegación</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s es producido por Mozilla. Nuestra misión es fomentar un Internet sano y abierto.<br/>\n"
+"<p>%1$s es producido por Mozilla. Nuestra misión es fomentar un Internet "
+"sano y abierto.<br/>\n"
 "<a href=\"%2$s\">Aprender más</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Enviar datos de uso anónimos"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Aprender más"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Eliminar historial de navegación"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Expandir"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "Buscar una app que pueda abrir el enlace"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ninguna de las aplicaciones en tu dispositivo puede abrir este enlace. Puedes salir de %1$s para buscar en %2$s por una app que pueda."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ninguna de las aplicaciones en tu dispositivo puede abrir este enlace. "
+"Puedes salir de %1$s para buscar en %2$s por una app que pueda."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +491,9 @@ msgstr "Abrir"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Los archivos descargados <b>no serán eliminados</b> cuando limpies el historial de %1$s."
+msgstr ""
+"Los archivos descargados <b>no serán eliminados</b> cuando limpies el "
+"historial de %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +526,17 @@ msgstr "No se pudo conectar"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>El sitio podría estar temporalmente no disponible o demasiado ocupado. Vuelve a intentarlo en un rato.</li>\n"
-"        <li>Si no puedes cargar ninguna página, comprueba el servicio de datos de tu dispositivo móvil o la conexión Wi-Fi.</li>\n"
+"        <li>El sitio podría estar temporalmente no disponible o demasiado"
+" ocupado. Vuelve a intentarlo en un rato.</li>\n"
+"        <li>Si no puedes cargar ninguna página, comprueba el servicio de "
+"datos de tu dispositivo móvil o la conexión Wi-Fi.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,12 +553,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Revisa la dirección por errores de tipeo como <strong>ww</strong>.example.com en lugar de <strong>www</strong>.example.com</li>\n"
-"        <li>Si no puedes cargar ninguna página, revisa el servicio de datos de tu dispositivo o la conexión Wi-Fi.</li>\n"
+"        <li>Revisa la dirección por errores de tipeo como "
+"<strong>ww</strong>.example.com en lugar de "
+"<strong>www</strong>.example.com</li>\n"
+"        <li>Si no puedes cargar ninguna página, revisa el servicio de "
+"datos de tu dispositivo o la conexión Wi-Fi.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -528,13 +572,17 @@ msgstr "La dirección no es válida"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Las direcciones Web usualmente son escritas como <strong>http://www.example.com/</strong></li>\n"
-"  <li>Asegúrate de que estás usando barras oblicuas (por ejemplo <strong>/</strong>).</li>\n"
+"  <li>Las direcciones Web usualmente son escritas como "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Asegúrate de que estás usando barras oblicuas (por ejemplo "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -544,11 +592,13 @@ msgstr "La página no está redirigiendo adecuadamente"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Este problema puede ser causado a veces por desactivar o rechazar cookies.</li>\n"
+"  <li>Este problema puede ser causado a veces por desactivar o rechazar "
+"cookies.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -558,11 +608,13 @@ msgstr "La dirección no fue comprendida"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Puede que debas instalar otro software para abrir esta dirección.</li>\n"
+"  <li>Puede que debas instalar otro software para abrir esta "
+"dirección.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -572,15 +624,20 @@ msgstr "Falló la conexión segura"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Este puede ser un problema con la configuración del servidor, o puede ser alguien tratando de suplantar al servidor.</li>\n"
-"  <li>Si te has conectado exitosamente a este servidor en el pasado, el error quizá sea temporal y debieras poder volver a intentarlo más tarde. </li>\n"
+"  <li>Este puede ser un problema con la configuración del servidor, o "
+"puede ser alguien tratando de suplantar al servidor.</li>\n"
+"  <li>Si te has conectado exitosamente a este servidor en el pasado, el "
+"error quizá sea temporal y debieras poder volver a intentarlo más tarde. "
+"</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -625,8 +682,12 @@ msgstr "Abrir enlace en nueva pestaña"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Las imágenes guardadas y compartidas <b>no serán eliminadas</b> cuando borres el historial de %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Las imágenes guardadas y compartidas <b>no serán eliminadas</b> cuando "
+"borres el historial de %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -635,9 +696,13 @@ msgstr "Potencia tu privacidad"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
 msgstr ""
-"Lleva la navegación privada al siguiente nivel. Bloquea anuncios publicitarios y otro tipo de contenido que puede rastrearte a través de los sitios y ralentizar los tiempos de carga de las páginas."
+"Lleva la navegación privada al siguiente nivel. Bloquea anuncios "
+"publicitarios y otro tipo de contenido que puede rastrearte a través de "
+"los sitios y ralentizar los tiempos de carga de las páginas."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -646,8 +711,12 @@ msgstr "Tu búsqueda, a tu manera"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "¿Buscas algo diferente? Elige otro motor de búsqueda predeterminado en los ajustes."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"¿Buscas algo diferente? Elige otro motor de búsqueda predeterminado en "
+"los ajustes."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -658,7 +727,9 @@ msgstr "Añade atajos a tu pantalla de inicio"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
 msgstr ""
 
 #. First run tour (Privacy): Title
@@ -670,8 +741,12 @@ msgstr "Haz de la privacidad un hábito"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Establece %1$s como navegador predeterminado y experimenta los beneficios de la navegación privada al abrir páginas web desde otras aplicaciones."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Establece %1$s como navegador predeterminado y experimenta los beneficios"
+" de la navegación privada al abrir páginas web desde otras aplicaciones."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -709,6 +784,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Cancelar"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -724,3 +807,36 @@ msgstr "Abrir enlace en pestaña seleccionada"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Abrir"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/es-ES/app.po
+++ b/locales/es-ES/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-17 10:35+0000\n"
 "Last-Translator: avelper <avelper@mozilla-hispano.org>\n"
-"Language-Team: es_ES <LL@li.org>\n"
 "Language: es_ES\n"
+"Language-Team: es_ES <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s te da el control.</p>\n"
 "<p>Úsalo como navegador privado:\n"
 "  <ul>\n"
 "    <li>Busca y navega en la propia aplicación</li>\n"
-"    <li>Bloquea a los rastreadores (o cambia los ajustes para permitirlos)</li>\n"
-"    <li>Limpia para borrar cookies y los historiales de búsqueda y navegación</li>\n"
+"    <li>Bloquea a los rastreadores (o cambia los ajustes para "
+"permitirlos)</li>\n"
+"    <li>Limpia para borrar cookies y los historiales de búsqueda y "
+"navegación</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>Mozilla es la autora de %1$s. Nuestra misión es promover un Internet saludable y abierto.<br/>\n"
+"<p>Mozilla es la autora de %1$s. Nuestra misión es promover un Internet "
+"saludable y abierto.<br/>\n"
 "<a href=\"%2$s\">Descubre más</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Enviar datos de uso anónimos"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Descubrir más"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Eliminar historial de navegación"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Expandir"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "Busca una aplicación que pueda abrir este enlace"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ninguna de las aplicaciones de tu dispositivo puede abrir este enlace. Puedes salir de %1$s para buscar en %2$s una aplicación compatible."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ninguna de las aplicaciones de tu dispositivo puede abrir este enlace. "
+"Puedes salir de %1$s para buscar en %2$s una aplicación compatible."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +491,9 @@ msgstr "Abrir"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Los archivos descargados <b>no serán eliminados</b> cuando borres el historial de %1$s."
+msgstr ""
+"Los archivos descargados <b>no serán eliminados</b> cuando borres el "
+"historial de %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +526,17 @@ msgstr "No se pudo conectar"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Puede que el sitio esté ocupado o no esté disponible temporalmente. Vuelve a intentarlo en unos minutos.</li>\n"
-"        <li>Si no puedes cargar ninguna página, comprueba la conexión de datos o Wi-Fi de tu dispositivo.</li>\n"
+"        <li>Puede que el sitio esté ocupado o no esté disponible "
+"temporalmente. Vuelve a intentarlo en unos minutos.</li>\n"
+"        <li>Si no puedes cargar ninguna página, comprueba la conexión de "
+"datos o Wi-Fi de tu dispositivo.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +553,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Comprueba que la dirección no tiene ningún error como\n"
 "          <strong>ww</strong>.example.com en vez de\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Si no puedes cargar ninguna página, comprueba la conexión de datos o Wi-Fi de tu dispositivo.</li>\n"
+"        <li>Si no puedes cargar ninguna página, comprueba la conexión de "
+"datos o Wi-Fi de tu dispositivo.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,12 +572,15 @@ msgstr "La dirección no es válida"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Las direcciones web se suelen escribir así: <strong>http://www.example.com/</strong></li>\n"
+"  <li>Las direcciones web se suelen escribir así: "
+"<strong>http://www.example.com/</strong></li>\n"
 "  <li>Asegúrate de usar las barras oblicuas (<strong>/</strong>).</li>\n"
 "</ul>"
 
@@ -546,11 +591,13 @@ msgstr "La página no se está redireccionando adecuadamente"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>A veces, el problema se produce por desactivar o no aceptar el uso de cookies.</li>\n"
+"  <li>A veces, el problema se produce por desactivar o no aceptar el uso "
+"de cookies.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +607,13 @@ msgstr "No se entendió la dirección"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Puede que necesites instalar otro software para abrir esta dirección.</li>\n"
+"  <li>Puede que necesites instalar otro software para abrir esta "
+"dirección.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,16 +623,20 @@ msgstr "Falló la conexión segura"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Puede que haya un problema con la configuración del servidor o puede\n"
+"  <li>Puede que haya un problema con la configuración del servidor o "
+"puede\n"
 "que alguien esté intentando suplantar al servidor.</li>\n"
-"  <li>Si ya te habías conectado antes a este servidor sin problemas, puede que el error\n"
+"  <li>Si ya te habías conectado antes a este servidor sin problemas, "
+"puede que el error\n"
 "sea temporal y puedes intentarlo más tarde.</li>\n"
 "</ul>"
 
@@ -629,8 +682,12 @@ msgstr "Abrir enlace en una pestaña nueva"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Las imágenes guardadas y compartidas <b>no se borrarán</b> cuando elimines el historial de %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Las imágenes guardadas y compartidas <b>no se borrarán</b> cuando "
+"elimines el historial de %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -639,8 +696,13 @@ msgstr "Potencia tu privacidad"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Lleva la navegación privada al siguiente nivel. Bloquea anuncios y otros contenidos que puedan rastrearte a través de los sitios y ralentizar la carga de las páginas."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Lleva la navegación privada al siguiente nivel. Bloquea anuncios y otros "
+"contenidos que puedan rastrearte a través de los sitios y ralentizar la "
+"carga de las páginas."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -649,8 +711,12 @@ msgstr "Tu búsqueda, a tu manera"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "¿Buscas algo diferente? Elige otro motor de búsqueda predeterminado en Ajustes."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"¿Buscas algo diferente? Elige otro motor de búsqueda predeterminado en "
+"Ajustes."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -661,8 +727,12 @@ msgstr "Añade accesos directos a tu pantalla de inicio"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Vuelve a visitar tus sitios favoritos en %1$s de forma instantánea. En el menú %1$s, selecciona \"Agregar a la pantalla de inicio\"."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Vuelve a visitar tus sitios favoritos en %1$s de forma instantánea. En el"
+" menú %1$s, selecciona \"Agregar a la pantalla de inicio\"."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -673,8 +743,12 @@ msgstr "Haz de la privacidad un hábito"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Establece %1$s como navegador predeterminado y experimenta los beneficios de la navegación privada al abrir páginas web desde otras aplicaciones."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Establece %1$s como navegador predeterminado y experimenta los beneficios"
+" de la navegación privada al abrir páginas web desde otras aplicaciones."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -712,6 +786,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Cancelar"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -727,3 +809,36 @@ msgstr "Abrir enlace en la pestaña seleccionada"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Abrir"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/es-MX/app.po
+++ b/locales/es-MX/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-17 16:33+0000\n"
 "Last-Translator: Elisa X. <ee.sf2000@gmail.com>\n"
-"Language-Team: es_MX <LL@li.org>\n"
 "Language: es_MX\n"
+"Language-Team: es_MX <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s te da el control.</p>\n"
 "<p>Úsalo como navegador privado:\n"
 "  <ul>\n"
 "    <li>Buscar y navegar directamente en la aplicación</li>\n"
-"    <li>Bloquear rastreadores (o actualizar las preferencias para permitirlos)</li>\n"
-"    <li>Borrar para eliminar cookies e historiales de búsqueda y navegación</li>\n"
+"    <li>Bloquear rastreadores (o actualizar las preferencias para "
+"permitirlos)</li>\n"
+"    <li>Borrar para eliminar cookies e historiales de búsqueda y "
+"navegación</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s fue creado por Mozilla. Nuestra misión es promover un Internet saludable y abierto.<br/>\n"
+"<p>%1$s fue creado por Mozilla. Nuestra misión es promover un Internet "
+"saludable y abierto.<br/>\n"
 "<a href=\"%2$s\">Aprender más</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Enviar datos de uso de forma anónima"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Saber más"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Eliminar historial de navegación"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Expandir"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "Buscar una aplicación que pueda abrir el enlace"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ninguna de las aplicaciones en tu dispositivo puede abrir este enlace. Puedes salir de %1$s para buscar una aplicación compatible en %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ninguna de las aplicaciones en tu dispositivo puede abrir este enlace. "
+"Puedes salir de %1$s para buscar una aplicación compatible en %2$s."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +491,9 @@ msgstr "Abrir"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Los archivos descargados <b>no serán eliminados</b> al borrar el historial de %1$s."
+msgstr ""
+"Los archivos descargados <b>no serán eliminados</b> al borrar el "
+"historial de %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +526,17 @@ msgstr "No se puede conectar"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>El sitio podría estar temporalmente no disponible o demasiado ocupado. Vuelve a intentarlo en un rato.</li>\n"
-"        <li>Si no puedes cargar ninguna página, comprueba el servicio de datos de tu dispositivo móvil o la conexión Wi-Fi.</li>\n"
+"        <li>El sitio podría estar temporalmente no disponible o demasiado"
+" ocupado. Vuelve a intentarlo en un rato.</li>\n"
+"        <li>Si no puedes cargar ninguna página, comprueba el servicio de "
+"datos de tu dispositivo móvil o la conexión Wi-Fi.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +553,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Comprueba que la dirección no tiene ningún error como\n"
 "          <strong>ww</strong>.example.com en vez de\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Si no puedes cargar ninguna página, comprueba la conexión de datos o Wi-Fi de tu dispositivo.</li>\n"
+"        <li>Si no puedes cargar ninguna página, comprueba la conexión de "
+"datos o Wi-Fi de tu dispositivo.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +572,17 @@ msgstr "La dirección no es válida"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Las direcciones Web usualmente son escritas como <strong>http://www.example.com/</strong></li>\n"
-"  <li>Asegúrate de que estás usando barras oblicuas (por ejemplo <strong>/</strong>).</li>\n"
+"  <li>Las direcciones Web usualmente son escritas como "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Asegúrate de que estás usando barras oblicuas (por ejemplo "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +592,13 @@ msgstr "La página no se está redireccionando apropiadamente"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Este problema a veces es causado por deshabilitar o rechazar cookies.</li>\n"
+"  <li>Este problema a veces es causado por deshabilitar o rechazar "
+"cookies.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +608,13 @@ msgstr "No se comprende la dirección"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Puede que necesites instalar otro software para abrir esta dirección.</li>\n"
+"  <li>Puede que necesites instalar otro software para abrir esta "
+"dirección.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +624,20 @@ msgstr "Falló la conexión segura"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Este puede ser un problema con la configuración del servidor, o puede ser alguien tratando de suplantar al servidor.</li>\n"
-"  <li>Si te has conectado exitosamente a este servidor en el pasado, el error quizá sea temporal y debieras poder volver a intentarlo más tarde. </li>\n"
+"  <li>Este puede ser un problema con la configuración del servidor, o "
+"puede ser alguien tratando de suplantar al servidor.</li>\n"
+"  <li>Si te has conectado exitosamente a este servidor en el pasado, el "
+"error quizá sea temporal y debieras poder volver a intentarlo más tarde. "
+"</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +682,12 @@ msgstr "Abrir enlace en una nueva pestaña"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Las imágenes guardadas y compartidas <b>no se borrarán</b> cuando elimines el historial %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Las imágenes guardadas y compartidas <b>no se borrarán</b> cuando "
+"elimines el historial %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,9 +696,13 @@ msgstr "Potencia tu privacidad"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
 msgstr ""
-"Lleva la navegación privada a otro nivel. Bloquea anuncios publicitarios y otro tipo de contenido que puede rastrearte a través de los sitios y ralentizar el tiempo de descarga de las páginas."
+"Lleva la navegación privada a otro nivel. Bloquea anuncios publicitarios "
+"y otro tipo de contenido que puede rastrearte a través de los sitios y "
+"ralentizar el tiempo de descarga de las páginas."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -648,8 +711,12 @@ msgstr "Tu búsqueda, a tu manera"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "¿Buscas algo diferente? Elige otro motor de búsqueda predeterminado en la configuración."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"¿Buscas algo diferente? Elige otro motor de búsqueda predeterminado en la"
+" configuración."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -660,8 +727,12 @@ msgstr "Agrega atajos a la pantalla principal"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Regresa rápidamente a tus sitios favoritos en %1$s. Selecciona \"agregar a la página de inicio\" desde el menú %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Regresa rápidamente a tus sitios favoritos en %1$s. Selecciona \"agregar "
+"a la página de inicio\" desde el menú %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -672,8 +743,12 @@ msgstr "Acostúmbrate a la privacidad"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Establece %1$s como navegador predeterminado y experimenta los beneficios de la navegación privada al abrir páginas web desde otras aplicaciones."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Establece %1$s como navegador predeterminado y experimenta los beneficios"
+" de la navegación privada al abrir páginas web desde otras aplicaciones."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -711,6 +786,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Cancelar"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -726,3 +809,36 @@ msgstr "Abrir enlace en una pestaña seleccionada"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Abrir"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/eu/app.po
+++ b/locales/eu/app.po
@@ -6,17 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 13:50+0000\n"
 "Last-Translator: julenx <julenx@gmail.com>\n"
-"Language-Team: eu <LL@li.org>\n"
 "Language: eu\n"
+"Language-Team: eu <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -166,21 +165,25 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s(e)k agintea ematen dizu.</p>\n"
 "<p>Erabili nabigatzaile pribatu gisa:\n"
 "  <ul>\n"
 "    <li>Bilatu eta nabigatu aplikaziotik zuzenean</li>\n"
-"    <li>Blokeatu jarraipena (edo eguneratu ezarpenak jarraipena onartzeko)</li>\n"
+"    <li>Blokeatu jarraipena (edo eguneratu ezarpenak jarraipena "
+"onartzeko)</li>\n"
 "    <li>Ezabatu cookieak eta bilaketa- eta nabigatze-historia</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>Mozillak egina da %1$s. Internet osasuntsu eta irekia sustatzea da gure misioa.<br/>\n"
+"<p>Mozillak egina da %1$s. Internet osasuntsu eta irekia sustatzea da "
+"gure misioa.<br/>\n"
 "<a href=\"%2$s\">Argibide gehiago</a></p>"
 
 msgctxt "preference_category_search"
@@ -281,9 +284,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Bidali erabilpen-datu anonimoak"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Argibide gehiago"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -319,6 +338,16 @@ msgstr "Ezabatu nabigatze-historia"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Zabaldu"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -429,8 +458,12 @@ msgstr "Bilatu lotura ireki dezakeen aplikazio bat"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ez dago lotura hau irekitzeko gai den aplikaziorik zure gailuan. %1$s utz dezakezu lotura ireki dezaken aplikazio bat %2$s(e)n bilatzeko."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ez dago lotura hau irekitzeko gai den aplikaziorik zure gailuan. %1$s utz"
+" dezakezu lotura ireki dezaken aplikazio bat %2$s(e)n bilatzeko."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -455,7 +488,9 @@ msgstr "Ireki"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Deskargatutako fitxategiak <b>ez dira ezabatuko</b> %1$s(r)en historia ezabatzean."
+msgstr ""
+"Deskargatutako fitxategiak <b>ez dira ezabatuko</b> %1$s(r)en historia "
+"ezabatzean."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -488,13 +523,17 @@ msgstr "Ezin da konektatu"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Gunea une batez desgaituta edo oso lanpetuta egon daiteke. Saiatu berriro minutu batzuen buruan.</li>\n"
-"        <li>Ezin baduzu beste orririk kargatu, egiaztatu zure gailu mugikorraren datu- edo WiFi-konexioa.</li>\n"
+"        <li>Gunea une batez desgaituta edo oso lanpetuta egon daiteke. "
+"Saiatu berriro minutu batzuen buruan.</li>\n"
+"        <li>Ezin baduzu beste orririk kargatu, egiaztatu zure gailu "
+"mugikorraren datu- edo WiFi-konexioa.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -511,14 +550,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Helbidea ondo begiratu mota honetako erroreak ekiditeko:\n"
 "          <strong>ww</strong>.adibidea.eus \n"
 "          <strong>www</strong>.adibidea.eus-en ordez</li>\n"
-"        <li>Ezin baduzu inolako orririk kargatu, begiratu zure gailuaren datu- edo WiFi-konexioa.</li>\n"
+"        <li>Ezin baduzu inolako orririk kargatu, begiratu zure gailuaren "
+"datu- edo WiFi-konexioa.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -528,13 +569,17 @@ msgstr "Helbidea ez da baliozkoa"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Web helbideak normalean <strong>http://www.adibidea.eus/</strong> formatukoak dira</li>\n"
-"  <li>Ziurtatu aurrerako barrak erabiltzen dituzula (hau da, <strong>/</strong>).</li>\n"
+"  <li>Web helbideak normalean <strong>http://www.adibidea.eus/</strong> "
+"formatukoak dira</li>\n"
+"  <li>Ziurtatu aurrerako barrak erabiltzen dituzula (hau da, "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -544,11 +589,13 @@ msgstr "Orriak ez du birbideraketa ondo egiten"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Arazo hau baliteke cookieak desgaituta eduki edo ez onartzeagatik izatea.</li>\n"
+"  <li>Arazo hau baliteke cookieak desgaituta eduki edo ez onartzeagatik "
+"izatea.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -558,11 +605,13 @@ msgstr "Ez da helbidea ulertu"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Agian bestelako softwarea instalatu behar duzu helbide hau irekitzeko.</li>\n"
+"  <li>Agian bestelako softwarea instalatu behar duzu helbide hau "
+"irekitzeko.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -572,16 +621,19 @@ msgstr "Konexio seguruak huts egin du"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
 "  <li>Hau zerbitzariaren konfigurazio-errore batengatik edo\n"
 "norbait zerbitzariaren nortasuna hartzen ari delako izan daiteke.</li>\n"
-"  <li>Aurretik zerbitzari honetara behar bezala konektatu bazara, errorea\n"
+"  <li>Aurretik zerbitzari honetara behar bezala konektatu bazara, errorea"
+"\n"
 "behin-behinekoa izan daiteke eta geroago saia zaitezke.</li>\n"
 "</ul>"
 
@@ -627,8 +679,12 @@ msgstr "Ireki lotura fitxa berrian"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Deskargatutako eta partekatutako irudiak <b>ez dira ezabatuko</b> %1$s(r)en historia ezabatzean."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Deskargatutako eta partekatutako irudiak <b>ez dira ezabatuko</b> "
+"%1$s(r)en historia ezabatzean."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +693,13 @@ msgstr "Indartu zure pribatutasuna"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Eraman nabigatze pribatua hurrengo mailara. Blokeatu iragarkiak eta webguneetan zehar zure jarraipena egin edo orrien karga-denbora makal dezaketen edukiak."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Eraman nabigatze pribatua hurrengo mailara. Blokeatu iragarkiak eta "
+"webguneetan zehar zure jarraipena egin edo orrien karga-denbora makal "
+"dezaketen edukiak."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +708,12 @@ msgstr "Bilaketa, zure erara"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Zerbait desberdinaren bila? Aukeratu beste bilaketa-motor lehenetsi bat ezarpenetan."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Zerbait desberdinaren bila? Aukeratu beste bilaketa-motor lehenetsi bat "
+"ezarpenetan."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +724,12 @@ msgstr "Gehitu lasterbideak zure hasierako pantailan"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Itzuli azkar batean zure gogoko guneetara %1$s(r)en. Hautatu 'Gehitu hasierako pantailan' %1$s menutik."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Itzuli azkar batean zure gogoko guneetara %1$s(r)en. Hautatu 'Gehitu "
+"hasierako pantailan' %1$s menutik."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +740,12 @@ msgstr "Egizu pribatutasuna zure ohitura"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Ezarri %1$s nabigatzaile lehenetsi gisa eta eskuratu nabigatze pribatuaren onurak beste aplikazioetatik web orriak irekitzean."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Ezarri %1$s nabigatzaile lehenetsi gisa eta eskuratu nabigatze "
+"pribatuaren onurak beste aplikazioetatik web orriak irekitzean."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +783,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Utzi"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +806,36 @@ msgstr "Ireki lotura hautatutako fitxan"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Ireki"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/fa/app.po
+++ b/locales/fa/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 18:48+0000\n"
 "Last-Translator: Amin Mahmudian <amin.mahmudian@gmail.com>\n"
-"Language-Team: fa <LL@li.org>\n"
 "Language: fa\n"
+"Language-Team: fa <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 0)) || ((n == 1))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s شما را در کنترل قرار میدهد.</p>\n"
 "<p>از این برنامه به عنوان یک مرورگر ناشناس استفاده کنید:\n"
 "  <ul>\n"
 "    <li>بدون خروج از برنامه، اینترنت را جست‌وجو و مرور کنید</li>\n"
-"    <li>ردیاب‌ها را مسدود کنید (یا اینکه تنظیمات خود را برای اجازه دادن به ردیاب‌ها تغییر دهید)</li>\n"
-"    <li>پاک کنید تا اطلاعاتی مانند کوکی‌ها و همچنین جست‌وجوها و تاریخچه مرور حذف شوند</li>\n"
+"    <li>ردیاب‌ها را مسدود کنید (یا اینکه تنظیمات خود را برای اجازه دادن "
+"به ردیاب‌ها تغییر دهید)</li>\n"
+"    <li>پاک کنید تا اطلاعاتی مانند کوکی‌ها و همچنین جست‌وجوها و تاریخچه "
+"مرور حذف شوند</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s توسّط موزیلا منتشر شده است. مأموریت ما تا رواج یک اینترنت سالم، باز است.<br/>\n"
+"<p>%1$s توسّط موزیلا منتشر شده است. مأموریت ما تا رواج یک اینترنت سالم، "
+"باز است.<br/>\n"
 "<a href=\"%2$s\">بیشتر بدانید</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "ارسال داده‌های ناشناس مربوط به شیوه استفاده"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "اطلاعات بیشتر"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "حذف تاریخچه مرور"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "بازکردن"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,13 @@ msgstr "برنامه‌ای برای باز کردن پیوند پیدا کنی�
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "هیچکدام از برنامه‌های روی دستگاه شما امکان باز کردن این پیوند را ندارند. می‌توانید از %1$s خارج شوید تا در %2$s برای برنامه‌ای که بتواند اینکار را انجام دهد جست‌وجو کنید."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"هیچکدام از برنامه‌های روی دستگاه شما امکان باز کردن این پیوند را ندارند. "
+"می‌توانید از %1$s خارج شوید تا در %2$s برای برنامه‌ای که بتواند اینکار را"
+" انجام دهد جست‌وجو کنید."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +492,9 @@ msgstr "باز کردن"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "وقتی تاریخ‌چه %1$s را پاک می‌کنید، پرونده‌های دریافت شده <b>پاک نخواهند شد</b>."
+msgstr ""
+"وقتی تاریخ‌چه %1$s را پاک می‌کنید، پرونده‌های دریافت شده <b>پاک نخواهند "
+"شد</b>."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +527,17 @@ msgstr "اتصال ناموفق بود"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"<li>سایت می‌تواند موقتا در دسترس نباشد یا خیلی شلوغ باشد. چند لحظه دیگر مجددا تلاش کنید.</li>\n"
-"<li>اگر شما نمی‌توانید هیچ صفحه‌ای را باز کنید، اتصال داده یا Wi-Fi دستگاه خود را بررسی کنید.</li> \n"
+"<li>سایت می‌تواند موقتا در دسترس نباشد یا خیلی شلوغ باشد. چند لحظه دیگر "
+"مجددا تلاش کنید.</li>\n"
+"<li>اگر شما نمی‌توانید هیچ صفحه‌ای را باز کنید، اتصال داده یا Wi-Fi "
+"دستگاه خود را بررسی کنید.</li> \n"
 "</ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +554,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "<li>نشانی را برای اشتباهات تایپی بررسی کنید که مثلا\n"
 "<strong>ww </strong>.example.com به طور اشتباه به جای \n"
 "<strong>www</strong>.example.com وارد نشده باشد.</li> \n"
-"<li>اگر نمی‌توانید هیچ صفحه‌ای را بارگذاری کنید، اتصال شبکهٔ رایانهٔ خود را بررسی کنید.</li>\n"
+"<li>اگر نمی‌توانید هیچ صفحه‌ای را بارگذاری کنید، اتصال شبکهٔ رایانهٔ خود "
+"را بررسی کنید.</li>\n"
 "</ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +573,17 @@ msgstr "این آدرس معتبر نیست"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"<li>نشانی‌های وب معمولاً به این صورت نوشته می‌شوند <strong>http://www.example.com/</strong></li>\n"
-"<li>مطمئن شوید که از ممیز درست استفاده می‌کنید (یعنی <strong>/</strong>).</li>\n"
+"<li>نشانی‌های وب معمولاً به این صورت نوشته می‌شوند "
+"<strong>http://www.example.com/</strong></li>\n"
+"<li>مطمئن شوید که از ممیز درست استفاده می‌کنید (یعنی "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +593,13 @@ msgstr "تغییر مسیر این صفحه به درستی انجام نمی‌
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>این مشکل گاهی ممکن است به دلیل غیرفعال کردن یا قبول نکردن کوکی‌ها اتفاق بیافتد.</li>\n"
+"  <li>این مشکل گاهی ممکن است به دلیل غیرفعال کردن یا قبول نکردن کوکی‌ها "
+"اتفاق بیافتد.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +609,13 @@ msgstr "آدرس قابل فهم نبود"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>ممکن است لازم باشد تا برنامهٔ دیگری را برای باز کردن این آدرس نصب کنید.</li>\n"
+"  <li>ممکن است لازم باشد تا برنامهٔ دیگری را برای باز کردن این آدرس نصب "
+"کنید.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +625,19 @@ msgstr "اتصال امن شکست خورد"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"<li>امکان دارید این اشکالی در تنظیمات کارگزار باشد، یا کسی به دنبال بازی کردن نقش این کارگزار باشد.</li>\n"
-"<li>اگر پیش از این بدون دریافت این خطا از این وب‌گاه بازدید کرده‌اید، این خطا امکان دارد موقتی باشد، بعداً دوباره تلاش کنید.</li>\n"
+"<li>امکان دارید این اشکالی در تنظیمات کارگزار باشد، یا کسی به دنبال بازی "
+"کردن نقش این کارگزار باشد.</li>\n"
+"<li>اگر پیش از این بدون دریافت این خطا از این وب‌گاه بازدید کرده‌اید، این"
+" خطا امکان دارد موقتی باشد، بعداً دوباره تلاش کنید.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +682,12 @@ msgstr "بازکردن پیوند در زبانه جدید"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "وقتی شما تاریخ‌جه %1$s را پاک می‌کنید، تصاویر ذخیره یا هم‌رسان شده <b>پاک نخواهند شد</b>."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"وقتی شما تاریخ‌جه %1$s را پاک می‌کنید، تصاویر ذخیره یا هم‌رسان شده <b>پاک"
+" نخواهند شد</b>."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +696,13 @@ msgstr "قدرت حریم‌شخصی خود را افزایش دهید"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "مرور خصوصی را به سطحی بالاتر ببرید. تبلیغات و دیگر محتواهایی را مسدود کنید که می‌توانند شما را در سراسر سایت‌ها ردیابی و زمان‌های بارگذاری صفحه را خراب کنند."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"مرور خصوصی را به سطحی بالاتر ببرید. تبلیغات و دیگر محتواهایی را مسدود "
+"کنید که می‌توانند شما را در سراسر سایت‌ها ردیابی و زمان‌های بارگذاری صفحه"
+" را خراب کنند."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +711,12 @@ msgstr "جستجوی شما، به روش شما"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "به دنبال چیز متفاوتی هستید؟ موتور جستجوی پیش‌فرض دیگری را در تنظیمات انتخاب کنید."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"به دنبال چیز متفاوتی هستید؟ موتور جستجوی پیش‌فرض دیگری را در تنظیمات "
+"انتخاب کنید."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +727,12 @@ msgstr "میان‌برها را به صفحه خانگی خود اضافه کن
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "در %1$s به سرعت به سایت‌های محبوب خود برگردید. فقط «افزودن به صفحه خانگی» را از منوی %1$s انتخاب کنید."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"در %1$s به سرعت به سایت‌های محبوب خود برگردید. فقط «افزودن به صفحه خانگی»"
+" را از منوی %1$s انتخاب کنید."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +743,12 @@ msgstr "حفظ حریم خصوصی را به یک عادت تبدیل کنید"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "%1$s را به عنوان مرورگر پیش‌فرض خود انتخاب کنید و وقتی از اپ‌های دیگر صفحه‌های وب را باز می‌کنید از مزایای مرور خصوصی بهره‌مند شوید."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"%1$s را به عنوان مرورگر پیش‌فرض خود انتخاب کنید و وقتی از اپ‌های دیگر "
+"صفحه‌های وب را باز می‌کنید از مزایای مرور خصوصی بهره‌مند شوید."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +786,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "انصراف"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +809,36 @@ msgstr "بازکردن پیوند در زبانه انتخاب شده"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "باز کردن"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/fr/app.po
+++ b/locales/fr/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 23:01+0000\n"
 "Last-Translator: Théo Chevalier <theo.chevalier11@gmail.com>\n"
-"Language-Team: fr <LL@li.org>\n"
 "Language: fr\n"
+"Language-Team: fr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 0) || (n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s vous aide à rester aux commandes.</p>\n"
 "<p>Utilisez-le comme un navigateur privé :\n"
 "<ul>\n"
 "<li>Effectuez des recherches et naviguez depuis l’application</li>\n"
-"<li>Bloquez les traqueurs (ou modifiez les paramètres pour les autoriser)</li>\n"
-"<li>Effacez les cookies, ainsi que les historiques de navigation et de recherche</li>\n"
+"<li>Bloquez les traqueurs (ou modifiez les paramètres pour les "
+"autoriser)</li>\n"
+"<li>Effacez les cookies, ainsi que les historiques de navigation et de "
+"recherche</li>\n"
 "</ul>\n"
 "</p>\n"
-"<p>%1$s est réalisé par Mozilla. Notre mission est de défendre l’ouverture et la bonne santé d’Internet.<br/>\n"
+"<p>%1$s est réalisé par Mozilla. Notre mission est de défendre "
+"l’ouverture et la bonne santé d’Internet.<br/>\n"
 "<a href=\"%2$s\">En savoir plus</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Envoyer des statistiques d’utilisation anonymes"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "En savoir plus"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Effacer l’historique de navigation"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Développer"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,13 @@ msgstr "Trouver une application capable d’ouvrir ce lien"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Aucune des applications de votre appareil n’est capable d’ouvrir ce lien. Vous pouvez quitter %1$s pour rechercher dans %2$s une application qui en est capable."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Aucune des applications de votre appareil n’est capable d’ouvrir ce lien."
+" Vous pouvez quitter %1$s pour rechercher dans %2$s une application qui "
+"en est capable."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +492,9 @@ msgstr "Ouvrir"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Les fichiers téléchargés <b>ne seront pas supprimés</b> lorsque vous effacez l’historique de %1$s."
+msgstr ""
+"Les fichiers téléchargés <b>ne seront pas supprimés</b> lorsque vous "
+"effacez l’historique de %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +527,17 @@ msgstr "La connexion a échoué"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"<li>Le site est peut-être temporairement indisponible ou surchargé. Réessayez plus tard ;</li>\n"
-"<li> Si vous n’arrivez à naviguer sur aucun site, vérifiez la connexion données ou Wi-Fi de votre appareil.</li>\n"
+"<li>Le site est peut-être temporairement indisponible ou surchargé. "
+"Réessayez plus tard ;</li>\n"
+"<li> Si vous n’arrivez à naviguer sur aucun site, vérifiez la connexion "
+"données ou Wi-Fi de votre appareil.</li>\n"
 "</ul> "
 
 msgctxt "error_timeout_title"
@@ -513,12 +554,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"<li>Veuillez vérifier la syntaxe de l’adresse (saisie de <strong>ww</strong>.example.com au lieu de <strong>www</strong>.example.com par exemple) ;</li>\n"
-"<li>Si vous n’arrivez à naviguer sur aucun site, vérifiez la connexion données ou Wi-Fi de votre appareil.</li>\n"
+"<li>Veuillez vérifier la syntaxe de l’adresse (saisie de "
+"<strong>ww</strong>.example.com au lieu de "
+"<strong>www</strong>.example.com par exemple) ;</li>\n"
+"<li>Si vous n’arrivez à naviguer sur aucun site, vérifiez la connexion "
+"données ou Wi-Fi de votre appareil.</li>\n"
 "</ul> "
 
 msgctxt "error_malformedURI_title"
@@ -528,13 +573,17 @@ msgstr "L’adresse n’est pas valide"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"<li>La syntaxe des adresses web est généralement <strong>http://www.example.com/</strong> ;</li>\n"
-"<li>Assurez-vous de bien utiliser des barres obliques (c.-à-d. <strong>/</strong>).</li>\n"
+"<li>La syntaxe des adresses web est généralement "
+"<strong>http://www.example.com/</strong> ;</li>\n"
+"<li>Assurez-vous de bien utiliser des barres obliques (c.-à-d. "
+"<strong>/</strong>).</li>\n"
 "</ul> "
 
 msgctxt "error_redirectLoop_title"
@@ -544,11 +593,13 @@ msgstr "La page n’est pas redirigée correctement"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>La cause de ce problème peut être la désactivation ou le refus des cookies.</li>\n"
+"  <li>La cause de ce problème peut être la désactivation ou le refus des "
+"cookies.</li>\n"
 "</ul>\n"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -558,11 +609,13 @@ msgstr "L’adresse n’a pas été reconnue"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Il est peut-être nécessaire d’installer une autre application pour ouvrir ce type d’adresse.</li>\n"
+"  <li>Il est peut-être nécessaire d’installer une autre application pour "
+"ouvrir ce type d’adresse.</li>\n"
 "</ul>\n"
 
 msgctxt "error_sslhandshake_title"
@@ -572,14 +625,18 @@ msgstr "Échec de la connexion sécurisée"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
-" <ul> <li>Ceci peut être dû à un problème de configuration du serveur ou à une personne essayant d’usurper l’identité du serveur.</li> <li>Si vous avez déjà pu vous connecter à ce serveur, l’erreur "
-"est peut-être temporaire et vous pouvez essayer à nouveau plus tard.</li> </ul> "
+" <ul> <li>Ceci peut être dû à un problème de configuration du serveur ou "
+"à une personne essayant d’usurper l’identité du serveur.</li> <li>Si vous"
+" avez déjà pu vous connecter à ce serveur, l’erreur est peut-être "
+"temporaire et vous pouvez essayer à nouveau plus tard.</li> </ul> "
 
 msgctxt "error_generic_title"
 msgid "Oops"
@@ -623,8 +680,12 @@ msgstr "Ouvrir le lien dans un nouvel onglet"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Les images partagées ou enregistrées <b>ne seront pas supprimées</b> lorsque vous effacez l’historique de %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Les images partagées ou enregistrées <b>ne seront pas supprimées</b> "
+"lorsque vous effacez l’historique de %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -633,8 +694,13 @@ msgstr "Renforcez votre vie privée"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "La navigation privée passe au niveau supérieur. Dites adieu aux publicités et autres traqueurs qui vous espionnent et ralentissent le chargement des pages web."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"La navigation privée passe au niveau supérieur. Dites adieu aux "
+"publicités et autres traqueurs qui vous espionnent et ralentissent le "
+"chargement des pages web."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -643,8 +709,12 @@ msgstr "Recherchez à votre manière"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Vous recherchez quelque chose de différent ? Choisissez un autre moteur de recherche par défaut dans les paramètres."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Vous recherchez quelque chose de différent ? Choisissez un autre moteur "
+"de recherche par défaut dans les paramètres."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -655,8 +725,12 @@ msgstr "Ajoutez des raccourcis sur votre écran d’accueil"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Retournez voir vos sites préférés dans %1$s rapidement. Sélectionnez simplement « Ajouter à l’écran d’accueil » depuis le menu de %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Retournez voir vos sites préférés dans %1$s rapidement. Sélectionnez "
+"simplement « Ajouter à l’écran d’accueil » depuis le menu de %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -667,8 +741,13 @@ msgstr "Reprenez votre vie privée en main"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Définissez %1$s en tant que navigateur par défaut et bénéficiez d’une navigation privée dès que vous ouvrez les pages web à partir d’autres applications."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Définissez %1$s en tant que navigateur par défaut et bénéficiez d’une "
+"navigation privée dès que vous ouvrez les pages web à partir d’autres "
+"applications."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -706,6 +785,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Annuler"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -721,3 +808,36 @@ msgstr "Ouvrir le lien dans l’onglet sélectionné"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Ouvrir"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/fy-NL/app.po
+++ b/locales/fy-NL/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-07-31 06:25+0000\n"
 "Last-Translator: Fjoerfoks <fryskefirefox@gmail.com>\n"
 "Language: fy_NL\n"
@@ -287,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Anonime brûksgegevens ferstjoere"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Mear ynfo"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -324,6 +340,16 @@ msgstr "Navigaasjeskiednis wiskje"
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -753,6 +779,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Annulearje"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -767,5 +801,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/ga-IE/app.po
+++ b/locales/ga-IE/app.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-07-28 17:03+0000\n"
 "Last-Translator: Kevin Scannell <kscanne@gmail.com>\n"
 "Language: ga_IE\n"
@@ -285,9 +285,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Seol sonraí úsáide gan ainm"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Tuilleadh eolais"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -322,6 +338,16 @@ msgstr "Glan an stair bhrabhsála"
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -749,6 +775,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Cealaigh"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -763,5 +797,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/he/app.po
+++ b/locales/he/app.po
@@ -2,23 +2,24 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 15:30+0000\n"
 "Last-Translator: ItielMaN <itiel_yn8@walla.com>\n"
-"Language-Team: he <LL@li.org>\n"
 "Language: he\n"
+"Language-Team: he <LL@li.org>\n"
+"Plural-Forms: nplurals=4; plural=(((((0 == 0)) && (!((n >= 0 && n <= "
+"10)))) && (((n % 10) == 0))) ? 2 : (((n == 1)) && ((0 == 0))) ? 0 : (((n "
+"== 2)) && ((0 == 0))) ? 1 : 3)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,10 +169,12 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>השליטה חוזרת לידיך עם %1$s.</p>\n"
@@ -182,7 +185,8 @@ msgstr ""
 "    <li>ניתן לאפס כדי למחוק עוגיות כמו גם את היסטוריית החיפוש</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s מבית מוזילה Mozilla. המטרה שלנו היא לטפח אינטרנט בריא ופתוח.<br/>\n"
+"<p>%1$s מבית מוזילה Mozilla. המטרה שלנו היא לטפח אינטרנט בריא ופתוח.<br/>"
+"\n"
 "<a href=\"%2$s\">מידע נוסף</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "שליחת נתוני שימוש אנונימיים"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "מידע נוסף"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "מחיקת היסטורית גלישה"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "הרחבה"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "חיפוש יישומון שיוכל לפתוח את הקישור"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "אף אחד מהיישומים שבהתקן שלך יכולים לפתוח את הקישור הזה. ניתן לעזוב את %1$s כדי לחפש תחת %2$s יישומון שיכול לבצע זאת."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"אף אחד מהיישומים שבהתקן שלך יכולים לפתוח את הקישור הזה. ניתן לעזוב את "
+"%1$s כדי לחפש תחת %2$s יישומון שיכול לבצע זאת."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -490,13 +524,17 @@ msgstr "לא ניתן להתחבר"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>האתר עשוי להיות לא זמין כעת או עמוס. נא לנסות שוב בעוד מספר רגעים.</li>\n"
-"        <li>אם לא ניתן לטעון גם דפים אחרים, נא לבדוק את חיבור הנתונים או האינטרנט האלחוטי של ההתקן שברשותך.</li>\n"
+"        <li>האתר עשוי להיות לא זמין כעת או עמוס. נא לנסות שוב בעוד מספר "
+"רגעים.</li>\n"
+"        <li>אם לא ניתן לטעון גם דפים אחרים, נא לבדוק את חיבור הנתונים או "
+"האינטרנט האלחוטי של ההתקן שברשותך.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +551,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>נא לוודא שהכתובת הוכנסה כראוי, למשל\n"
 "          <strong>ww</strong>.example.com במקום\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>אם אין אפשרות לטעון דפים אחרים, נא לבדוק את חיבור הנתונים או האינטרנט האלחוטי של ההתקן.</li>\n"
+"        <li>אם אין אפשרות לטעון דפים אחרים, נא לבדוק את חיבור הנתונים או "
+"האינטרנט האלחוטי של ההתקן.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +570,17 @@ msgstr "כתובת זו אינה חוקית"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>כתובות אינטרנט לרוב נכתבות בצורה דומה לזו: <strong>http://www.example.com/</strong></li>\n"
-"  <li>יש לוודא כי נעשה שימוש בלוכסנים קדמיים (כלומר <strong>/</strong>).</li>\n"
+"  <li>כתובות אינטרנט לרוב נכתבות בצורה דומה לזו: "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>יש לוודא כי נעשה שימוש בלוכסנים קדמיים (כלומר "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +590,13 @@ msgstr "הדף מבצע העברה לא תקינה"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>פעולה זו נגרמת לעתים כאשר עוגיות מנוטרלות או כאשר מסרבים לקבל עוגיות.</li>\n"
+"  <li>פעולה זו נגרמת לעתים כאשר עוגיות מנוטרלות או כאשר מסרבים לקבל "
+"עוגיות.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,7 +606,8 @@ msgstr "כתובת זו אינה מובנת"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -574,15 +621,19 @@ msgstr "קישור מאובטח נכשל"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>ייתכן שישנה בעיה בהגדרות השרת או שגורם כלשהו מנסה להתחזות אליו.</li>\n"
-"  <li>במידה שהצלחת להתחבר לאתר כראוי בעבר, ייתכן ששגיאה זו היא זמנית בלבד, ואפשר יהיה לנסות שוב מאוחר יותר.</li>\n"
+"  <li>ייתכן שישנה בעיה בהגדרות השרת או שגורם כלשהו מנסה להתחזות "
+"אליו.</li>\n"
+"  <li>במידה שהצלחת להתחבר לאתר כראוי בעבר, ייתכן ששגיאה זו היא זמנית "
+"בלבד, ואפשר יהיה לנסות שוב מאוחר יותר.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,7 +678,9 @@ msgstr "פתיחת קישור בלשונית חדשה"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
 msgstr "תמונות שמורות ומשותפות <b>לא יימחקו</b> בעת מחיקת ההיסטוריה של %1$s."
 
 #. First run tour (Default browser): Title
@@ -637,7 +690,9 @@ msgstr "חיזוק הפרטיות שלך"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
 msgstr ""
 
 #. First run tour (Search): Title
@@ -647,7 +702,9 @@ msgstr "החיפוש שלך, בדרך שלך"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr ""
 
 #. First run tour (Shortcut): Title
@@ -659,7 +716,9 @@ msgstr "הוספת קיצורי דרך למסך הבית שלך"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
 msgstr ""
 
 #. First run tour (Privacy): Title
@@ -671,7 +730,9 @@ msgstr ""
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
 msgstr ""
 
 msgctxt "firstrun_close_button"
@@ -710,6 +771,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "ביטול"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +794,36 @@ msgstr "פתיחת קישור בלשונית שנבחרה"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "פתיחה"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/hi-IN/app.po
+++ b/locales/hi-IN/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-21 15:24+0000\n"
 "Last-Translator: ravi.103151 <ravi.103151@gmail.com>\n"
-"Language-Team: hi_IN <LL@li.org>\n"
 "Language: hi_IN\n"
+"Language-Team: hi_IN <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 0)) || ((n == 1))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -166,21 +165,25 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s आपको नियंत्रण में रखता है.</p>\n"
 "<p>इसे एक निजी ब्राउज़र के रूप में प्रयोग करें:\n"
 "  <ul>\n"
 "    <li>ऐप में दाहिनी ओर खोजें और ब्राउज करें</li>\n"
-"    <li>ट्रैकर्स अवरुद्ध करें (या ट्रैकर्स को अनुमति देने के लिए सेटिंग्स अपडेट करें)</li>\n"
+"    <li>ट्रैकर्स अवरुद्ध करें (या ट्रैकर्स को अनुमति देने के लिए सेटिंग्स"
+" अपडेट करें)</li>\n"
 "    <li>कुकीज़ के साथ खोज और ब्राउज़िंग इतिहास हटाने के लिए मिटाएँ</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s मोज़िला द्वारा निर्मित है. हमारा मिशन एक स्वस्थ, उन्मुक्त इंटरनेट को बढ़ावा देना है.<br/>\n"
+"<p>%1$s मोज़िला द्वारा निर्मित है. हमारा मिशन एक स्वस्थ, उन्मुक्त इंटरनेट"
+" को बढ़ावा देना है.<br/>\n"
 "<a href=\"%2$s\">और जानें</a></p>"
 
 msgctxt "preference_category_search"
@@ -281,9 +284,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "अज्ञात उपयोग आंकड़ा भेजें"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "और अधिक जानें"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -319,6 +338,16 @@ msgstr "ब्राउज़िंग इतिहास मिटाएँ"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "विस्तार"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -429,8 +458,12 @@ msgstr "एक ऐप ढूंढें जो लिंक खोल सकत
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "आपके डिवाइस पर मौजूद कोई ऐप इस लिंक को खोलने में सक्षम नहीं है. आप एक एप के लिए %2$s की खोज हेतु %1$s को छोड़ सकते हैं जो कर सकता है."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"आपके डिवाइस पर मौजूद कोई ऐप इस लिंक को खोलने में सक्षम नहीं है. आप एक एप "
+"के लिए %2$s की खोज हेतु %1$s को छोड़ सकते हैं जो कर सकता है."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -488,13 +521,17 @@ msgstr "संपर्क करने में असमर्थ"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>यह साइट अस्थाई रूप से अनुपलब्ध या बहुत व्यस्त हो सकता है. कुछ ही क्षणों में फिर से प्रयास करें.</li>\n"
-"        <li>यदि आप कोई पृष्ठ लोड करने में असमर्थ हैं, तो अपने मोबाइल उपकरण के डेटा या वाई-फाई कनेक्शन की जाँच करें.</li>\n"
+"        <li>यह साइट अस्थाई रूप से अनुपलब्ध या बहुत व्यस्त हो सकता है. कुछ"
+" ही क्षणों में फिर से प्रयास करें.</li>\n"
+"        <li>यदि आप कोई पृष्ठ लोड करने में असमर्थ हैं, तो अपने मोबाइल "
+"उपकरण के डेटा या वाई-फाई कनेक्शन की जाँच करें.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -511,12 +548,15 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li><strong>ww</strong>जैसी लिखित त्रुटियों के लिए पते की जाँच करें. <strong>www</strong>के बजाय example.com. example.com</li>\n"
-"        <li>यदि आप किसी भी पृष्ठ लोड करने में असमर्थ हैं, तो अपने उपकरण के डेटा या वाई-फाई कनेक्शन की जाँच करें।</li>\n"
+"        <li><strong>ww</strong>जैसी लिखित त्रुटियों के लिए पते की जाँच "
+"करें. <strong>www</strong>के बजाय example.com. example.com</li>\n"
+"        <li>यदि आप किसी भी पृष्ठ लोड करने में असमर्थ हैं, तो अपने उपकरण "
+"के डेटा या वाई-फाई कनेक्शन की जाँच करें।</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -526,13 +566,17 @@ msgstr "पता वैध नहीं है"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>वेब पते आमतौर पर <strong>http://www.example.com/</strong> की तरह लिखे होते हैं</li>\n"
-"  <li>सुनिश्चित करें कि आप अग्रतियक स्लैश का उपयोग कर रहे हैं (यानी <strong>/</strong>).</li>\n"
+"  <li>वेब पते आमतौर पर <strong>http://www.example.com/</strong> की तरह "
+"लिखे होते हैं</li>\n"
+"  <li>सुनिश्चित करें कि आप अग्रतियक स्लैश का उपयोग कर रहे हैं (यानी "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -542,11 +586,13 @@ msgstr "पृष्ठ ठीक से पुनर्निर्देशि
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>कभी-कभी इस समस्या का कारण कुकीज़ को स्वीकार करने से मना करना या अक्षम करना हो सकता है.</li>\n"
+"  <li>कभी-कभी इस समस्या का कारण कुकीज़ को स्वीकार करने से मना करना या "
+"अक्षम करना हो सकता है.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -556,11 +602,13 @@ msgstr "पता समझा नहीं गया था"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>आपको इस पते को खोलने के लिए अन्य सॉफ़्टवेयर संस्थापित करने की आवश्यकता हो सकती है.</li>\n"
+"  <li>आपको इस पते को खोलने के लिए अन्य सॉफ़्टवेयर संस्थापित करने की "
+"आवश्यकता हो सकती है.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -570,16 +618,20 @@ msgstr "सुरक्षित संपर्क विफ़ल"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>यह सर्वर के कॉन्फ़िगरेशन में एक समस्या हो सकती है, या यह हो सकता है\n"
+"  <li>यह सर्वर के कॉन्फ़िगरेशन में एक समस्या हो सकती है, या यह हो सकता है"
+"\n"
 "कोई सर्वर का प्रतिरूपण करने का प्रयास कर रहा है.</li>\n"
-"  <li>अगर आप पूर्व में इस सर्वर से सफलतापूर्वक जुड़ चुके है, तो त्रुटि अस्थायी हो सकती है, और आप बाद में पुनः प्रयास कर सकते हैं.</li>\n"
+"  <li>अगर आप पूर्व में इस सर्वर से सफलतापूर्वक जुड़ चुके है, तो त्रुटि "
+"अस्थायी हो सकती है, और आप बाद में पुनः प्रयास कर सकते हैं.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -624,8 +676,12 @@ msgstr "नए टैब में कड़ी खोलें"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "सहेजे गए और साझा की गई छवियाँ <b>हटाई नहीं जाएँगी</b> जब आप %1$s इतिहास को मिटाएँगे."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"सहेजे गए और साझा की गई छवियाँ <b>हटाई नहीं जाएँगी</b> जब आप %1$s इतिहास "
+"को मिटाएँगे."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -634,8 +690,12 @@ msgstr "अपनी गोपनीयता को बढ़ाएँ"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "निजी ब्राउज़िंग को अगले स्तर तक ले. विज्ञापन और अन्य सामग्री को ब्लॉक करे जो आपको सभी साइट को ट्रैक कर सकता हैं और पृष्ट लोड समय को बढ़ा देता हैं."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"निजी ब्राउज़िंग को अगले स्तर तक ले. विज्ञापन और अन्य सामग्री को ब्लॉक करे"
+" जो आपको सभी साइट को ट्रैक कर सकता हैं और पृष्ट लोड समय को बढ़ा देता हैं."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -644,7 +704,9 @@ msgstr "आपका खोज, आपका रास्ता"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "कुछ अलग खोंज रहे हैं? सेटिंग्स में दूसरा डिफ़ॉल्ट खोज इंजन चुने."
 
 #. First run tour (Shortcut): Title
@@ -656,8 +718,12 @@ msgstr "अपने मुख्य स्क्रीन पर शॉर्�
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "%1$s में अपनी पसंदीदा साइटों को तेज़ी से वापस जाएँ. बस %1$s मेनू से \"मुख्य स्क्रीन पर जोड़ें\" का चयन करें।"
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"%1$s में अपनी पसंदीदा साइटों को तेज़ी से वापस जाएँ. बस %1$s मेनू से "
+"\"मुख्य स्क्रीन पर जोड़ें\" का चयन करें।"
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -668,8 +734,12 @@ msgstr "गोपनीयता एक आदत बनाये"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "%1$s को अपने तयशुदा ब्राउज़र के रूप में सेट करें और जब आप अन्य ऐप्स से वेबपृष्ठ खोलते हैं तब निजी ब्राउज़िंग के फायदे प्राप्त करें."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"%1$s को अपने तयशुदा ब्राउज़र के रूप में सेट करें और जब आप अन्य ऐप्स से "
+"वेबपृष्ठ खोलते हैं तब निजी ब्राउज़िंग के फायदे प्राप्त करें."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -707,6 +777,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "रद्द करें"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -722,3 +800,36 @@ msgstr "चयनित टैब में कड़ी खोलें"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "खोलें"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/hsb/app.po
+++ b/locales/hsb/app.po
@@ -6,17 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 20:14+0000\n"
 "Last-Translator: Michael Wolf <milupo@sorbzilla.de>\n"
-"Language-Team: hsb <LL@li.org>\n"
 "Language: hsb\n"
+"Language-Team: hsb <LL@li.org>\n"
+"Plural-Forms: nplurals=4; plural=(((((0 == 0)) && (((n % 100) >= 3 && (n "
+"% 100) <= 4))) || (((0 % 100) >= 3 && (0 % 100) <= 4))) ? 2 : ((((0 == "
+"0)) && (((n % 100) == 1))) || (((0 % 100) == 1))) ? 0 : ((((0 == 0)) && "
+"(((n % 100) == 2))) || (((0 % 100) == 2))) ? 1 : 3)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -166,21 +168,25 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s da was kontrolu wobchować.</p>\n"
 "<p>Wužiwajće jón jako priwatny wobhladowak:\n"
 "  <ul>\n"
 "    <li>Pytajće a přehladujće direktnje w nałoženju</li>\n"
-"    <li>Blokujće přesćěhowaki (abo aktualizujće nastajenja, zo byšće přesćěhowaki dowolił)</li>\n"
+"    <li>Blokujće přesćěhowaki (abo aktualizujće nastajenja, zo byšće "
+"přesćěhowaki dowolił)</li>\n"
 "    <li>Zhašejće placki a pytansku a přehladowansku historiju</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s so wot Mozilla wuwiwa. Naša misija je spěchowanje stroweho, wotewrjeneho interneta.<br/>\n"
+"<p>%1$s so wot Mozilla wuwiwa. Naša misija je spěchowanje stroweho, "
+"wotewrjeneho interneta.<br/>\n"
 "<a href=\"%2$s\">Dalše informacije</a></p>"
 
 msgctxt "preference_category_search"
@@ -281,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Anonymne wužiwanske daty pósłać"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Dalše informacije"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -319,6 +341,16 @@ msgstr "Přehladowansku historiju zhašeć"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Pokazać"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -429,8 +461,12 @@ msgstr "Nałoženje pytać, kotrež móže wotkaz wočinić"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Žane z nałoženjow na wašim graće njemóže tutón wotkaz wočinić. Móžeće %1$s wopušćić, zo byšće %2$s za nałoženjom přepytował."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Žane z nałoženjow na wašim graće njemóže tutón wotkaz wočinić. Móžeće "
+"%1$s wopušćić, zo byšće %2$s za nałoženjom přepytował."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -488,13 +524,17 @@ msgstr "Žadyn zwisk móžny"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Sydło njesteji snano nachwilu k dispoziciji abo je přećežene. Spytajće za mało wokomikow hišće raz.</li>\n"
-"        <li>Jeli njemóžeće strony začitać, přepruwujće datowy abo WLAN-zwisk wašeho mobilneho grata.</li>\n"
+"        <li>Sydło njesteji snano nachwilu k dispoziciji abo je přećežene."
+" Spytajće za mało wokomikow hišće raz.</li>\n"
+"        <li>Jeli njemóžeće strony začitać, přepruwujće datowy abo WLAN-"
+"zwisk wašeho mobilneho grata.</li>\n"
 "        </ul>"
 
 msgctxt "error_timeout_title"
@@ -511,14 +551,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Přepruwujće adresu za pisanskimi zmylkami kaž\n"
 "          <strong>ww</strong>.example.com město\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Jeli njemóžeće strony začitać, přepruwujće daty swojeho grata abo swój WLAN-zwisk.</li>\n"
+"        <li>Jeli njemóžeće strony začitać, přepruwujće daty swojeho grata"
+" abo swój WLAN-zwisk.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -528,13 +570,17 @@ msgstr "Adresa płaćiwa njeje"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Webadresy so z wašnjom kaž <strong>http://www.example.com/</strong> pisaja.</li>\n"
-"  <li>Zawěsćće, zo wužiwaće doprědka nachilene nakósne smužki (t.j. <strong>/</strong>).</li>\n"
+"  <li>Webadresy so z wašnjom kaž <strong>http://www.example.com/</strong>"
+" pisaja.</li>\n"
+"  <li>Zawěsćće, zo wužiwaće doprědka nachilene nakósne smužki (t.j. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -544,11 +590,13 @@ msgstr "Strona njeprawje posrědkuje"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Tutón problem so druhdy přez znjemóžnjenje abo wotpokazowanje plackow zawinuje.</li>\n"
+"  <li>Tutón problem so druhdy přez znjemóžnjenje abo wotpokazowanje "
+"plackow zawinuje.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -558,11 +606,13 @@ msgstr "Tuta adresa njeje so zrozumiła"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Snano dyrbiće druhe programy instalować, zo by so tuta adresa wočiniła.</li>\n"
+"  <li>Snano dyrbiće druhe programy instalować, zo by so tuta adresa "
+"wočiniła.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -572,16 +622,19 @@ msgstr "Wěsty zwisk móžny njeje"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
 "  <li>To móhło problem z konfiguraciju serwera być, abo móhło być,\n"
 "zo něchtó pospytuje serwer imitować.</li>\n"
-"  <li>Jeli sće ze serwerom w zańdźenosći wuspěšnje zwjazany był, móhł zmylk snano\n"
+"  <li>Jeli sće ze serwerom w zańdźenosći wuspěšnje zwjazany był, móhł "
+"zmylk snano\n"
 "nachwilny być a móžeće pozdźišo hišće raz spytać.</li>\n"
 "</ul>"
 
@@ -627,8 +680,12 @@ msgstr "Wotkaz w nowym rajtarku wočinić"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Składowane a dźělene wobrazy <b>so njezhašeja</b>, hdyž historiju %1$s zhašeće."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Składowane a dźělene wobrazy <b>so njezhašeja</b>, hdyž historiju %1$s "
+"zhašeće."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +694,13 @@ msgstr "Zesylńće swoju priwatnosć"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Zběhńće priwatne přehladowanje na přichodnu wyšu runinu. Blokujće wabjenje a hinaši wobsah, kotryž móžeće přez sydła slědować a začitanske časy stronow podlěšić."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Zběhńće priwatne přehladowanje na přichodnu wyšu runinu. Blokujće "
+"wabjenje a hinaši wobsah, kotryž móžeće přez sydła slědować a začitanske "
+"časy stronow podlěšić."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,7 +709,9 @@ msgstr "Waše pytanje kaž wy jo chceće"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "Pytaće za něčim druhim? Wubjerće druhu stndardnu pytawu w nastajenjach."
 
 #. First run tour (Shortcut): Title
@@ -659,8 +723,12 @@ msgstr "Přidajće swojej startowej wobrazowce tastowe skrótšenki"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Wróćće so spěšnje k swojim najlubšim sydłam w %1$s. Wubjerće prosće „Startowej wobrazowce přidać“ z menija %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Wróćće so spěšnje k swojim najlubšim sydłam w %1$s. Wubjerće prosće "
+"„Startowej wobrazowce přidać“ z menija %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +739,12 @@ msgstr "Přiwučće sej priwatnosć"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Nastajće %1$s jako swój standardny wobhladowak a zwužitkujće priwatne přehladowanje, hdyž webstrony z druhich nałoženjow wočinjeće."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Nastajće %1$s jako swój standardny wobhladowak a zwužitkujće priwatne "
+"přehladowanje, hdyž webstrony z druhich nałoženjow wočinjeće."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +782,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Přetorhnyć"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +805,36 @@ msgstr "Wotkaz we wubranym rajtarku wočinić"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Wočinić"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/hu/app.po
+++ b/locales/hu/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 13:39+0000\n"
 "Last-Translator: Balázs Meskó <meskobalazs@gmail.com>\n"
-"Language-Team: hu <LL@li.org>\n"
 "Language: hu\n"
+"Language-Team: hu <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,25 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>A %1$s az Ön kezébe adja az irányítást.</p>\n"
 "<p>Használja privát böngészőként:\n"
 "  <ul>\n"
 "    <li>Keressen és böngésszen közvetlenül az appban</li>\n"
-"    <li>Blokkolja a követőket (vagy frissítse a beállításokat az engedélyezéshez)</li>\n"
+"    <li>Blokkolja a követőket (vagy frissítse a beállításokat az "
+"engedélyezéshez)</li>\n"
 "    <li>Törölje a sütiket és a böngészési előzményeket is</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>A %1$s a Mozilla terméke. Küldetésünk az egészséges, nyílt Internet támogatása.<br/>\n"
+"<p>A %1$s a Mozilla terméke. Küldetésünk az egészséges, nyílt Internet "
+"támogatása.<br/>\n"
 "<a href=\"%2$s\">Tudjon meg többet</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +286,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Névtelen használati adatok küldése"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Tudjon meg többet"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +340,16 @@ msgstr "Böngészési előzmények törlése"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Kibontás"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +460,12 @@ msgstr "Keressen egy appot, amely meg tudja nyitni a hivatkozást"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Az eszközön lévő appok egyike sem tudja megnyitni ezt a hivatkozást. Kiléphet a %1$sból, és kereshet egy megfelelőt itt: %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Az eszközön lévő appok egyike sem tudja megnyitni ezt a hivatkozást. "
+"Kiléphet a %1$sból, és kereshet egy megfelelőt itt: %2$s."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +490,9 @@ msgstr "Megnyitás"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "A letöltött fájlok <b>nem kerülnek törlésre</b>, ha törli a %1$s előzményeit."
+msgstr ""
+"A letöltött fájlok <b>nem kerülnek törlésre</b>, ha törli a %1$s "
+"előzményeit."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +525,17 @@ msgstr "A kapcsolódás sikertelen"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>A webhely ideiglenesen nem érhető el, vagy túl elfoglalt. Próbálja újra néhány pillanat múlva.</li>\n"
-"        <li>Ha nem tölt be egyetlen oldal sem, akkor ellenőrizze a mobileszköz adat- vagy Wi-Fi kapcsolatát.</li>\n"
+"        <li>A webhely ideiglenesen nem érhető el, vagy túl elfoglalt. "
+"Próbálja újra néhány pillanat múlva.</li>\n"
+"        <li>Ha nem tölt be egyetlen oldal sem, akkor ellenőrizze a "
+"mobileszköz adat- vagy Wi-Fi kapcsolatát.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +552,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Ellenőrizze, hogy nem vétett gépelési hibát, például\n"
 "          <strong>ww</strong>. example.com a\n"
 "          <strong>www</strong>. example.com helyett</li>\n"
-"        <li>Ha egyetlen oldal sem tölt be, akkor ellenőrizze az eszköz adat- vagy Wi-Fi kapcsolatát.</li>\n"
+"        <li>Ha egyetlen oldal sem tölt be, akkor ellenőrizze az eszköz "
+"adat- vagy Wi-Fi kapcsolatát.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +571,17 @@ msgstr "A cím érvénytelen"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>A webcímek általában úgy néznek ki, mint a <strong>http://www.example.com/</strong></li>\n"
-"  <li>Győződjön meg róla, hogy perjeleket használ (tehát <strong>/</strong>).</li>\n"
+"  <li>A webcímek általában úgy néznek ki, mint a "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Győződjön meg róla, hogy perjeleket használ (tehát "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +591,13 @@ msgstr "Az oldal nem megfelelően van átirányítva"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Ezt a problémát néha a sütik letiltása vagy elutasítása okozza.</li>\n"
+"  <li>Ezt a problémát néha a sütik letiltása vagy elutasítása "
+"okozza.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +607,13 @@ msgstr "A cím nem volt érthető"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Lehet, hogy egyéb szoftvert kell telepítenie a cím megnyitásához.</li>\n"
+"  <li>Lehet, hogy egyéb szoftvert kell telepítenie a cím "
+"megnyitásához.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +623,19 @@ msgstr "A biztonságos kapcsolat sikertelen"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Ez lehet a kiszolgáló beállítási problémája, vagy lehet, hogy valaki megpróbálja megszemélyesíteni a kiszolgálót.</li>\n"
-"  <li>Ha a múltban sikeresen csatlakozott a kiszolgálóhoz, akkor a hiba ideiglenes lehet, és később újra megpróbálhatja.</li>\n"
+"  <li>Ez lehet a kiszolgáló beállítási problémája, vagy lehet, hogy "
+"valaki megpróbálja megszemélyesíteni a kiszolgálót.</li>\n"
+"  <li>Ha a múltban sikeresen csatlakozott a kiszolgálóhoz, akkor a hiba "
+"ideiglenes lehet, és később újra megpróbálhatja.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +680,12 @@ msgstr "Hivatkozás megnyitása új lapon"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "A mentett és megosztott képek <b>nem kerülnek törlésre</b>, ha törli a %1$s előzményeit."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"A mentett és megosztott képek <b>nem kerülnek törlésre</b>, ha törli a "
+"%1$s előzményeit."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +694,13 @@ msgstr "Tuningolja fel az adatvédelmét"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Emelje a privát a böngészést a következő szintre. Blokkolja a hirdetéseket, és más tartalmakat, amelyek követhetik az oldalak között, és lelassíthatják a betöltési sebességet."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Emelje a privát a böngészést a következő szintre. Blokkolja a "
+"hirdetéseket, és más tartalmakat, amelyek követhetik az oldalak között, "
+"és lelassíthatják a betöltési sebességet."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +709,12 @@ msgstr "Az Ön keresése, az Ön útja"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Valami mást keres? Válasszon másik alapértelmezett keresőmotort a Beállításokban."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Valami mást keres? Válasszon másik alapértelmezett keresőmotort a "
+"Beállításokban."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +725,12 @@ msgstr "Adjon ikonokat a kezdőképernyőre"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Térjen vissza gyorsan a kedven oldalaihoz a %1$sban. Csak válassza a „Hozzáadás a kezdőképernyőre” lehetőséget a %1$s menüből."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Térjen vissza gyorsan a kedven oldalaihoz a %1$sban. Csak válassza a "
+"„Hozzáadás a kezdőképernyőre” lehetőséget a %1$s menüből."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +741,12 @@ msgstr "Váljon szokásává az adatvédelem"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Állítsa be a %1$st alapértelmezett böngészőként, és kapja meg a privát böngészés előnyeit, amikor weboldalakat nyit meg a többi appból."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Állítsa be a %1$st alapértelmezett böngészőként, és kapja meg a privát "
+"böngészés előnyeit, amikor weboldalakat nyit meg a többi appból."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +784,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Mégse"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +807,36 @@ msgstr "Hivatkozás megnyitása a kiválasztott lapon"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Megnyitás"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/hy-AM/app.po
+++ b/locales/hy-AM/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-27 13:06+0000\n"
 "Last-Translator: Hrant <hrant.mozilla@gmail.com>\n"
-"Language-Team: hy_AM <LL@li.org>\n"
 "Language: hy_AM\n"
+"Language-Team: hy_AM <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 0) || (n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s-ը հնարավորություն է տալիս Ձեզ կառավարել:</p>\n"
 "<p>Օգտագործեք այն որպես գաղտնի դիտարկիչ.\n"
 "  <ul>\n"
 "    <li>Որոնեք և դիտարկեք անմիջապես հավելվածում</li>\n"
-"    <li>Արգելափակեք հետագծումները (կամ կարգավորեք՝ թույլատրելու դրանք)</li>\n"
-"    <li>Ջնջեք՝ cookie-ները, որոնումը և դիտարկումների պատմությունը մաքրելու համար</li>\n"
+"    <li>Արգելափակեք հետագծումները (կամ կարգավորեք՝ թույլատրելու "
+"դրանք)</li>\n"
+"    <li>Ջնջեք՝ cookie-ները, որոնումը և դիտարկումների պատմությունը "
+"մաքրելու համար</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s-ը պաշտպանված է Mozilla-ի կողմից: Մեր առաքելությունն է նպաստել համացանցի առողջ և բաց լինելուն:<br/>\n"
+"<p>%1$s-ը պաշտպանված է Mozilla-ի կողմից: Մեր առաքելությունն է նպաստել "
+"համացանցի առողջ և բաց լինելուն:<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Ուղարկել օգտագործման անանուն տվյալը"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Իմանալ ավելին"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Ջնջել դիտարկման պատմությունը"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Ընդարձակել"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,13 @@ msgstr "Գտեք հավելված, որը կարող է բացել հղումը"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ձեր սարքի ոչ մի հավելված չի կարողանում բացել այս հղումը: Դուք կարող եք թողնել %1$s-ը՝ որոնելու համար %2$s-ում այն հավելվածը, որը կարող է այն բացել:"
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ձեր սարքի ոչ մի հավելված չի կարողանում բացել այս հղումը: Դուք կարող եք "
+"թողնել %1$s-ը՝ որոնելու համար %2$s-ում այն հավելվածը, որը կարող է այն "
+"բացել:"
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -490,13 +525,17 @@ msgstr "Հնարավոր չէ կապակցվել"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Կայքը ժամանակավոր անհասանելի կամ զբաղված է: Փորձեք մի փոքր ավելի ուշ:</li>\n"
-"        <li>Եթե չկարողանաք բեռնել որևէ էջ՝ ստուգեք ձեր սարքի տվյալները կամ Wi-Fi կապակցումը:</li>\n"
+"        <li>Կայքը ժամանակավոր անհասանելի կամ զբաղված է: Փորձեք մի փոքր "
+"ավելի ուշ:</li>\n"
+"        <li>Եթե չկարողանաք բեռնել որևէ էջ՝ ստուգեք ձեր սարքի տվյալները "
+"կամ Wi-Fi կապակցումը:</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +552,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Ստուգեք հասցեն մուտքագրման սխալի համար, օրինակ՝\n"
 "          <strong>ww</strong>.example.com\n"
 "          <strong>www</strong>.example.com-ի փոխարեն</li>\n"
-"        <li>Եթե չի ստացվում բեռնել որևէ էջ, ապա ստուգեք սարքի տվյալները կամ Wi-Fi կապակցումը:</li>\n"
+"        <li>Եթե չի ստացվում բեռնել որևէ էջ, ապա ստուգեք սարքի տվյալները "
+"կամ Wi-Fi կապակցումը:</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +571,17 @@ msgstr "Հասցեն վավեր չէ"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Վեբ հասցեները սովորաբար գրվում են հետևյալ կերպ` <strong>http://www.example.com/</strong></li>\n"
-"  <li>Համոզվեք, որ օգտագործում եք հակադարձ սլեշներ (այսինքն` <strong>/</strong>):</li>\n"
+"  <li>Վեբ հասցեները սովորաբար գրվում են հետևյալ կերպ` "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Համոզվեք, որ օգտագործում եք հակադարձ սլեշներ (այսինքն` "
+"<strong>/</strong>):</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +591,13 @@ msgstr "Էջը հաջողությամբ չի վերաուղղորդվել"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Այս խնդիրը երբեմն կարող է հանգեցնել cookie-ների անջատմանը կամ մերժմանը:</li>\n"
+"  <li>Այս խնդիրը երբեմն կարող է հանգեցնել cookie-ների անջատմանը կամ "
+"մերժմանը:</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +607,13 @@ msgstr "Հասցեն չի հասկացվել"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Այս հասցեն բացելու համար, հնարավոր է, կարիք կլինի տեղադրել այլ ծրագիր:</li>\n"
+"  <li>Այս հասցեն բացելու համար, հնարավոր է, կարիք կլինի տեղադրել այլ "
+"ծրագիր:</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +623,20 @@ msgstr "Անվտանգ կապակցումը ձախողվեց"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Խնդիրը կարող է կապված լինել սպասարկիչի կազմաձևի հետ կամ, հնարավոր է, որ որևէ մեկը փորձում է որպես սպասարկիչ հանդես գալ:</li>\n"
-"  <li>Եթե դուք այս սպասարկիչին նախկինում հաջողությամբ եք կապակցվել, ապա սխալը կարող է ժամանակավոր բնույթ կրել և կարող եք կրկին փորձել ավելի ուշ:</li>\n"
+"  <li>Խնդիրը կարող է կապված լինել սպասարկիչի կազմաձևի հետ կամ, հնարավոր "
+"է, որ որևէ մեկը փորձում է որպես սպասարկիչ հանդես գալ:</li>\n"
+"  <li>Եթե դուք այս սպասարկիչին նախկինում հաջողությամբ եք կապակցվել, ապա "
+"սխալը կարող է ժամանակավոր բնույթ կրել և կարող եք կրկին փորձել ավելի "
+"ուշ:</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +681,12 @@ msgstr "Բացել հղումը նոր ներդիրում"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Պահպանված և համօգտագործված պատկերները <b>չեն ջնջվի</b>, երբ դուք ջնջեք %1$s-ը"
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Պահպանված և համօգտագործված պատկերները <b>չեն ջնջվի</b>, երբ դուք ջնջեք "
+"%1$s-ը"
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,7 +695,9 @@ msgstr "Հզորացրեք ձեր գաղտնիությունը"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
 msgstr ""
 
 #. First run tour (Search): Title
@@ -647,7 +707,9 @@ msgstr ""
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr ""
 
 #. First run tour (Shortcut): Title
@@ -659,7 +721,9 @@ msgstr ""
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
 msgstr ""
 
 #. First run tour (Privacy): Title
@@ -671,7 +735,9 @@ msgstr ""
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
 msgstr ""
 
 msgctxt "firstrun_close_button"
@@ -710,6 +776,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Չեղարկել"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +799,36 @@ msgstr "Բացել հղումը ընտրված ներդիրում"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Բացել"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/id/app.po
+++ b/locales/id/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-04 17:30+0000\n"
 "Last-Translator: Kiki <kelimutu.rizki@gmail.com>\n"
 "Language: id\n"
@@ -287,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Kirim data penggunaan anonim"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Pelajari lebih lanjut"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -324,6 +340,16 @@ msgstr "Hapus riwayat penjelajahan"
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -752,6 +778,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Batal"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -766,5 +800,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/it/app.po
+++ b/locales/it/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 19:40+0000\n"
 "Last-Translator: Francesco Lodolo <francesco.lodolo@mozillaitalia.org>\n"
-"Language-Team: it <LL@li.org>\n"
 "Language: it\n"
+"Language-Team: it <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 1)) && ((0 == 0))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>Prendi il controllo con %1$s.</p>\n"
 "<p>Utilizzalo per la navigazione anonima:\n"
 "  <ul>\n"
 "    <li>Cerca e naviga direttamente nell’app.</li>\n"
-"    <li>Blocca il tracciamento (o aggiorna le impostazioni per consentirlo).</li>\n"
-"    <li>Utilizza “Elimina” per rimuovere i cookie così come la cronologia di ricerca e navigazione.</li>\n"
+"    <li>Blocca il tracciamento (o aggiorna le impostazioni per "
+"consentirlo).</li>\n"
+"    <li>Utilizza “Elimina” per rimuovere i cookie così come la cronologia"
+" di ricerca e navigazione.</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s è realizzato da Mozilla. La nostra missione è promuovere un Internet integro e aperto.<br/>\n"
+"<p>%1$s è realizzato da Mozilla. La nostra missione è promuovere un "
+"Internet integro e aperto.<br/>\n"
 "<a href=\"%2$s\">Ulteriori informazioni</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Invia dati anonimi sull’uso"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Ulteriori informazioni"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Elimina cronologia di navigazione"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Espandi"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "Trova un app per aprire il link"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Nessuna delle app sul dispositivo è in grado di aprire questo link. È possibile uscire da %1$s e cercare una app adatta in %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Nessuna delle app sul dispositivo è in grado di aprire questo link. È "
+"possibile uscire da %1$s e cercare una app adatta in %2$s."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +491,9 @@ msgstr "Apri"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "I file scaricati <b>non verranno eliminati</b> quando si elimina la cronologia di %1$s."
+msgstr ""
+"I file scaricati <b>non verranno eliminati</b> quando si elimina la "
+"cronologia di %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +526,17 @@ msgstr "Connessione non riuscita"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Il sito potrebbe essere non disponibile o sovraccarico. Riprovare fra qualche istante.</li>\n"
-"  <li>Se non è possibile caricare alcuna pagina, controllare la connessione dati o Wi-Fi del dispositivo.</li>\n"
+"  <li>Il sito potrebbe essere non disponibile o sovraccarico. Riprovare "
+"fra qualche istante.</li>\n"
+"  <li>Se non è possibile caricare alcuna pagina, controllare la "
+"connessione dati o Wi-Fi del dispositivo.</li>\n"
 "</ul>"
 
 msgctxt "error_timeout_title"
@@ -513,12 +553,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Verificare se l'indirizzo contiene errori di battitura del tipo <strong>ww</strong>.example.com invece di <strong>www</strong>.example.com</li> \n"
-"  <li>Se non è possibile caricare alcuna pagina, controllare la connessione dati o Wi-Fi del dispositivo.</li>\n"
+"  <li>Verificare se l'indirizzo contiene errori di battitura del tipo "
+"<strong>ww</strong>.example.com invece di "
+"<strong>www</strong>.example.com</li> \n"
+"  <li>Se non è possibile caricare alcuna pagina, controllare la "
+"connessione dati o Wi-Fi del dispositivo.</li>\n"
 "</ul> "
 
 msgctxt "error_malformedURI_title"
@@ -528,13 +572,17 @@ msgstr "L’indirizzo non è valido"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Gli indirizzi internet normalmente si scrivono nella forma <strong>http://www.example.com/</strong></li>\n"
-"  <li>Verificare di aver utilizzato le barre corrette <strong>/</strong>.</li>\n"
+"  <li>Gli indirizzi internet normalmente si scrivono nella forma "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Verificare di aver utilizzato le barre corrette "
+"<strong>/</strong>.</li>\n"
 "</ul> "
 
 msgctxt "error_redirectLoop_title"
@@ -544,11 +592,13 @@ msgstr "Questa pagina non reindirizza in modo corretto"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Questo problema spesso è causato dal blocco o dal rifiuto dei cookie.</li>\n"
+"  <li>Questo problema spesso è causato dal blocco o dal rifiuto dei "
+"cookie.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -558,11 +608,13 @@ msgstr "Indirizzo non interpretabile"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>È necessario installare del software aggiuntivo per aprire questo indirizzo.</li>\n"
+"  <li>È necessario installare del software aggiuntivo per aprire questo "
+"indirizzo.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -572,15 +624,21 @@ msgstr "Connessione sicura non riuscita"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Potrebbe trattarsi di un problema nella configurazione del server oppure di un tentativo da parte di qualcuno di sostituirsi al server stesso.</li>\n"
-"  <li>Se è stato possibile connettersi a questo server in passato, il problema potrebbe essere solo temporaneo. Si consiglia di riprovare in seguito.</li>\n"
+"  <li>Potrebbe trattarsi di un problema nella configurazione del server "
+"oppure di un tentativo da parte di qualcuno di sostituirsi al server "
+"stesso.</li>\n"
+"  <li>Se è stato possibile connettersi a questo server in passato, il "
+"problema potrebbe essere solo temporaneo. Si consiglia di riprovare in "
+"seguito.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -625,8 +683,12 @@ msgstr "Apri link in nuova scheda"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Le immagini salvate e condivise <b>non verranno eliminate</b> quando si elimina la cronologia di %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Le immagini salvate e condivise <b>non verranno eliminate</b> quando si "
+"elimina la cronologia di %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -635,8 +697,13 @@ msgstr "Potenzia la tua privacy"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Porta la navigazione anonima al livello superiore. Blocca pubblicità e altri contenuti che cercano di seguirti attraverso siti diversi e rallentano il caricamento delle pagine."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Porta la navigazione anonima al livello superiore. Blocca pubblicità e "
+"altri contenuti che cercano di seguirti attraverso siti diversi e "
+"rallentano il caricamento delle pagine."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -645,8 +712,12 @@ msgstr "La ricerca a modo tuo"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Stavi cercando qualcos’altro? Scegli un altro motore di ricerca predefinito nelle Impostazioni."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Stavi cercando qualcos’altro? Scegli un altro motore di ricerca "
+"predefinito nelle Impostazioni."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -657,8 +728,12 @@ msgstr "Aggiungi collegamenti alla schermata principale"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Ritorna più velocemente ai tuoi siti preferiti con %1$s. Seleziona “Agg. a schermata principale\" dal menu di %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Ritorna più velocemente ai tuoi siti preferiti con %1$s. Seleziona “Agg. "
+"a schermata principale\" dal menu di %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -669,8 +744,12 @@ msgstr "Trasforma la privacy in un’abitudine"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Imposta %1$s come browser predefinito e goditi i vantaggi della navigazione anonima quando apri pagine web da altre app."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Imposta %1$s come browser predefinito e goditi i vantaggi della "
+"navigazione anonima quando apri pagine web da altre app."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -708,6 +787,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Annulla"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -723,3 +810,36 @@ msgstr "Apri link nella scheda selezionata"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Apri"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/ja/app.po
+++ b/locales/ja/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 13:50+0000\n"
 "Last-Translator: Kohei Yoshino <kohei.yoshino@gmail.com>\n"
-"Language-Team: ja <LL@li.org>\n"
 "Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,10 +167,12 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s ではあなたがすべてをコントロールできます。</p>\n"
@@ -283,9 +284,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "匿名の使用状況データを送信"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "詳細情報"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +338,16 @@ msgstr "閲覧履歴を消去"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "開く"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,7 +458,9 @@ msgstr "リンクを開けるアプリを探す"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
 msgstr "お使いの端末にはこのリンクを開けるアプリがありません。%1$s を離れて、開けるアプリを %2$s で探すことができます。"
 
 #. This label is shown above a list of apps that can be used to open a given
@@ -490,12 +519,16 @@ msgstr "正常に接続できませんでした"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>このサイトが一時的に利用できなくなっていたり、サーバーの負荷が高すぎて接続できなくなっている可能性があります。しばらくしてから再度試してください。</li>\n"
+"        "
+"<li>このサイトが一時的に利用できなくなっていたり、サーバーの負荷が高すぎて接続できなくなっている可能性があります。しばらくしてから再度試してください。</li>"
+"\n"
 "        <li>他のサイトも表示できない場合、デバイスのデータ接続や Wi-Fi 接続を確認してください。</li>\n"
 "      </ul>"
 
@@ -513,7 +546,8 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
@@ -530,13 +564,17 @@ msgstr "アドレスの書式が正しくありません"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>ウェブのアドレスは通常 <strong>http://www.example.com/</strong> のようなものになります。</li>\n"
-"  <li>円記号やバックスラッシュ (<strong>\\</strong>) ではなく、スラッシュ (<strong>/</strong>) が使われているか確認してください。</li>\n"
+"  <li>ウェブのアドレスは通常 <strong>http://www.example.com/</strong> "
+"のようなものになります。</li>\n"
+"  <li>円記号やバックスラッシュ (<strong>\\</strong>) ではなく、スラッシュ (<strong>/</strong>) "
+"が使われているか確認してください。</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,7 +584,8 @@ msgstr "ページの自動転送設定が正しくありません"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -560,7 +599,8 @@ msgstr "アドレスのプロトコルが不明です"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -574,9 +614,11 @@ msgstr "安全な接続ができませんでした"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
@@ -627,7 +669,9 @@ msgstr "リンクを新しいタブで開く"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
 msgstr "保存、共有された画像は %1$s の履歴を消去しても <b>削除されません</b>。"
 
 #. First run tour (Default browser): Title
@@ -637,7 +681,9 @@ msgstr "プライバシーを強化"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
 msgstr "プライベートブラウジングを次のレベルへと進めましょう。サイトを越えてあなたを追跡したり、ページの読み込みを遅くしたりする可能性のある広告その他のコンテンツを自動的にブロック。"
 
 #. First run tour (Search): Title
@@ -647,7 +693,9 @@ msgstr "好きな方法で検索"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "何か違ったものを探していますか？ 設定で別の検索エンジンを既定として選んでみましょう。"
 
 #. First run tour (Shortcut): Title
@@ -659,7 +707,9 @@ msgstr "ホーム画面にショートカットを追加"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
 msgstr "%1$s でもお気に入りのサイトへ素早く戻れます。%1$s のメニューから「ホーム画面に追加」を選択するだけ。"
 
 #. First run tour (Privacy): Title
@@ -671,7 +721,9 @@ msgstr "プライバシーを習慣に"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
 msgstr "%1$s を既定のブラウザーに設定して、他のアプリからウェブページを開いたときに、プライベートブラウジングの恩恵を受けましょう。"
 
 msgctxt "firstrun_close_button"
@@ -710,6 +762,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "キャンセル"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +785,36 @@ msgstr "リンクを選択したタブで開く"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "開く"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/ka/app.po
+++ b/locales/ka/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-20 19:56+0000\n"
 "Last-Translator: Georgianizator <georgianization@outlook.com>\n"
-"Language-Team: ka <LL@li.org>\n"
 "Language: ka\n"
+"Language-Team: ka <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s სრულად გიბრუნებთ მართვის სადავეებს.</p>\n"
 "<p>გამოიყენეთ როგორც პირადი ბრაუზერი:\n"
 "  <ul>\n"
 "    <li>მოძებნეთ და დაათვალიერეთ გვერდები</li>\n"
-"    <li>შეზღუდეთ მეთვალყურე ელემენტები (პარამეტრებიდან დაშვებაც შეიძლება)</li>\n"
-"    <li>გაასუფთავეთ და წაშალეთ ფუნთუშები, ძიების და თვალიერების ისტორია</li>\n"
+"    <li>შეზღუდეთ მეთვალყურე ელემენტები (პარამეტრებიდან დაშვებაც "
+"შეიძლება)</li>\n"
+"    <li>გაასუფთავეთ და წაშალეთ ფუნთუშები, ძიების და თვალიერების "
+"ისტორია</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s შექმნილია Mozilla-ს მიერ. ჩვენი მიზანი, ინტერნეტის გახსნილობა და სიჯანსაღეა.<br/>\n"
+"<p>%1$s შექმნილია Mozilla-ს მიერ. ჩვენი მიზანი, ინტერნეტის გახსნილობა და "
+"სიჯანსაღეა.<br/>\n"
 "<a href=\"%2$s\">შეიტყვეთ მეტი</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "გამოყენების შესახებ, ანონიმური მონაცემების გაგზავნა"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "შეიტყვეთ მეტი"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "ისტორიის წაშლა"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "გაშლა"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "პროგრამის მოძიება, რომელიც
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "თქვენს მოწყობილობაზე არსებულ არცერთ პროგრამას არ შეუძლია ამ ბმულის გახსნა. შეგიძლიათ დატოვოთ %1$s საჭირო პროგრამის %2$s-ში მოსაძიებლად."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"თქვენს მოწყობილობაზე არსებულ არცერთ პროგრამას არ შეუძლია ამ ბმულის "
+"გახსნა. შეგიძლიათ დატოვოთ %1$s საჭირო პროგრამის %2$s-ში მოსაძიებლად."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -490,13 +524,17 @@ msgstr "დაკავშირება ვერ ხერხდება"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>ეს საიტი შესაძლოა დროებით მიუწვდომელია ან ძალიან დატვირთულია. სცადეთ ხელახლა რამდენიმე წუთში.</li>\n"
-"        <li>თუ სხვა საიტების გახსნასაც ვერ ახერხებთ, მაშინ შეამოწმეთ მოწყობილობის მობილური ან Wi-Fi კავშირი.</li>\n"
+"        <li>ეს საიტი შესაძლოა დროებით მიუწვდომელია ან ძალიან დატვირთულია."
+" სცადეთ ხელახლა რამდენიმე წუთში.</li>\n"
+"        <li>თუ სხვა საიტების გახსნასაც ვერ ახერხებთ, მაშინ შეამოწმეთ "
+"მოწყობილობის მობილური ან Wi-Fi კავშირი.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +551,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>შეამოწმეთ აკრეფილი მისამართის სისწორე. მაგალითად\n"
 "          <strong>ww</strong>.example.com-ის ნაცვლად უნდა იყოს\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>თუ ვერცერთი საიტის გახსნას ვერ ახერხებთ, შეამოწმეთ მოწყობილობის მობილურ, ან Wi-Fi ინტერნეტთან კავშირი.</li>\n"
+"        <li>თუ ვერცერთი საიტის გახსნას ვერ ახერხებთ, შეამოწმეთ "
+"მოწყობილობის მობილურ, ან Wi-Fi ინტერნეტთან კავშირი.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +570,17 @@ msgstr "მისამართი არასწორია"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>საიტის მისამართები, ჩვეულებრივ, ასე იწერება <strong>http://www.example.com/</strong></li>\n"
-"  <li>დარწმუნდით, რომ წინ გადახრილ ხაზებს იყენებთ (ასეთს: <strong>/</strong>).</li>\n"
+"  <li>საიტის მისამართები, ჩვეულებრივ, ასე იწერება "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>დარწმუნდით, რომ წინ გადახრილ ხაზებს იყენებთ (ასეთს: "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,7 +590,8 @@ msgstr "ეს გვერდი არამართებულად გა
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -560,11 +605,13 @@ msgstr "მისამართის გაუგებარია"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>ამ ბმულის გასახსნელად, სავარაუდოდ, სხვა პროგრამის დაყენებაა საჭირო.</li>\n"
+"  <li>ამ ბმულის გასახსნელად, სავარაუდოდ, სხვა პროგრამის დაყენებაა "
+"საჭირო.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,9 +621,11 @@ msgstr "უსაფრთხო დაკავშირება ვერ მ
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
@@ -629,8 +678,12 @@ msgstr "ბმულის ახალ ჩანართში გახსნ
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "შენახული და გაზიარებული სურათები <b>არ წაიშლება</b> %1$s-ის ისტორიის გასუფთავებისას."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"შენახული და გაზიარებული სურათები <b>არ წაიშლება</b> %1$s-ის ისტორიის "
+"გასუფთავებისას."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -639,8 +692,13 @@ msgstr "გააძლიერეთ პირადი მონაცემ�
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "პირადი მონაცემების უსაფრთხოება ახალ დონეზეა აყვანილი. შეზღუდეთ სარეკლამო და სხვა შიგთავსი, რომლითაც საიტებზე თქვენი დევნაა შესაძლებელი და შეამცირეთ გვერდების ჩატვირთვის დრო."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"პირადი მონაცემების უსაფრთხოება ახალ დონეზეა აყვანილი. შეზღუდეთ სარეკლამო "
+"და სხვა შიგთავსი, რომლითაც საიტებზე თქვენი დევნაა შესაძლებელი და "
+"შეამცირეთ გვერდების ჩატვირთვის დრო."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -649,8 +707,12 @@ msgstr "მოიძიეთ გვერდები, თქვენებუ
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "რამე განსხვავებულს ეძებთ? აირჩიეთ სხვა საძიებო სისტემა ნაგულისხმევად, პარამეტრებიდან."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"რამე განსხვავებულს ეძებთ? აირჩიეთ სხვა საძიებო სისტემა ნაგულისხმევად, "
+"პარამეტრებიდან."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -661,8 +723,12 @@ msgstr "მალსახმობების დამატება მთ�
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "%1$s-ის დახმარებით, სწრაფად შეგიძლიათ დაუბრუნდეთ რჩეულ საიტებს. უბრალოდ, მიუთითეთ \"მთავარ ეკრანზე დამატება\", %1$s-ის მენიუდან."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"%1$s-ის დახმარებით, სწრაფად შეგიძლიათ დაუბრუნდეთ რჩეულ საიტებს. უბრალოდ, "
+"მიუთითეთ \"მთავარ ეკრანზე დამატება\", %1$s-ის მენიუდან."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -673,8 +739,12 @@ msgstr "ჩვევად აქციეთ პირადულობის 
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "დააყენეთ %1$s ნაგულისხმევ ბრაუზერად და ისარგებლეთ პირადულობის დაცვით, სხვა პროგრამებიდან ბმულებზე გადასვლის დროსაც."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"დააყენეთ %1$s ნაგულისხმევ ბრაუზერად და ისარგებლეთ პირადულობის დაცვით, "
+"სხვა პროგრამებიდან ბმულებზე გადასვლის დროსაც."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -712,6 +782,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "გაუქმება"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -727,3 +805,36 @@ msgstr "ბმულის გახსნა მითითებულ ჩა
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "გახსნა"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/kab/app.po
+++ b/locales/kab/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-17 07:32+0000\n"
 "Last-Translator: Slimane Amiri <slimane.amiri@gmail.com>\n"
-"Language-Team: kab <LL@li.org>\n"
 "Language: kab\n"
+"Language-Team: kab <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 0) || (n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,25 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s ad k-d-yefk afus ad teqqimeḍ d aqeṛṛu.</p>\n"
 "<p>Seqdec-it d iminig uslig:\n"
 "  <ul>\n"
 "    <li>Nadi sakin snirem akken iwata deg usnas</li>\n"
-"    <li>Sewḥel imesfuɣal (neγ snifel iγewwaṛen akken ad tsirgeḍ imesfuγal)</li>\n"
+"    <li>Sewḥel imesfuɣal (neγ snifel iγewwaṛen akken ad tsirgeḍ "
+"imesfuγal)</li>\n"
 "    <li>Sfeḍ inagan n tuqna akked amazray n tunigin d unadi</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s yesnulfa-t-id Mozilla. Tuγdaṭ-nneγ ad nḥareb γef internet yeldin d tezmert-is.<br/>\n"
+"<p>%1$s yesnulfa-t-id Mozilla. Tuγdaṭ-nneγ ad nḥareb γef internet yeldin "
+"d tezmert-is.<br/>\n"
 "<a href=\"%2$s\">Issin ugar</a></p>"
 
 msgctxt "preference_category_search"
@@ -231,7 +234,9 @@ msgstr "Sewḥel ineḍfaṛen-nniḍen n ugbur"
 
 msgctxt "preference_privacy_block_content_summary"
 msgid "May break some videos and Web pages"
-msgstr "Yezmer ad isewḥel kra n tvidyutin akked kra n isebtar Web ad d-banen akken iwata"
+msgstr ""
+"Yezmer ad isewḥel kra n tvidyutin akked kra n isebtar Web ad d-banen "
+"akken iwata"
 
 #. Preference Title: Secure Mode is a setting that prevents the app's content
 #. to show up in the "recent apps" screen          and prevents the user from
@@ -283,9 +288,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Azen isefka n useqdec udrigen"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Issin ugar"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +342,16 @@ msgstr "Kkes amazray n tunigin"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Snefli"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +462,12 @@ msgstr "Aff-d asnas izemren ad d-yeldi aseγwen"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ulac asnas deg ibenk-ik izemren ad d-yeldi aseγwen-agi. Tebγiḍ ad teffγeḍ si %1$s sakin ad d-nadiḍ %2$s akken ad d-tafeḍ asnas ilaqen."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ulac asnas deg ibenk-ik izemren ad d-yeldi aseγwen-agi. Tebγiḍ ad teffγeḍ"
+" si %1$s sakin ad d-nadiḍ %2$s akken ad d-tafeḍ asnas ilaqen."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -490,13 +525,17 @@ msgstr "Igguma ad iqqen"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Ahat asmel ulac-it akka tura neγ γur-s ttaɛebga. Σreḍ tikelt-nniḍen.</li>\n"
-"        <li>Ma yella ur tezmireḍ ara ad tinigeḍ ar usmel, senqed tuqqna-ik n isefka nγ Wi-Fi n yibenk-ik.</li>\n"
+"        <li>Ahat asmel ulac-it akka tura neγ γur-s ttaɛebga. Σreḍ tikelt-"
+"nniḍen.</li>\n"
+"        <li>Ma yella ur tezmireḍ ara ad tinigeḍ ar usmel, senqed tuqqna-"
+"ik n isefka nγ Wi-Fi n yibenk-ik.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,12 +552,15 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"<li>Senqed taseddast n tensa (tira n <strong>ww</strong>.example.com deg umḍiq n <strong>www</strong>.example.com par exemple) ;</li>\n"
-"<li>Ma yella ur tessawḍeḍ ara ad tinigeḍ deg ismal, senqed tuqqna n isefka neɣ Wi-Fi n yibenk-ik.</li>\n"
+"<li>Senqed taseddast n tensa (tira n <strong>ww</strong>.example.com deg "
+"umḍiq n <strong>www</strong>.example.com par exemple) ;</li>\n"
+"<li>Ma yella ur tessawḍeḍ ara ad tinigeḍ deg ismal, senqed tuqqna n "
+"isefka neɣ Wi-Fi n yibenk-ik.</li>\n"
 "</ul> "
 
 msgctxt "error_malformedURI_title"
@@ -528,13 +570,17 @@ msgstr "Tansa mačči d tameγtut"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Tansiwin web ttwarunt am <strong>http://www.example.com/</strong></li>\n"
-"  <li>Wali ma yella tseqdaceḍ amgal islacen (i.e. <strong>/</strong>).</li>\n"
+"  <li>Tansiwin web ttwarunt am "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Wali ma yella tseqdaceḍ amgal islacen (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -544,11 +590,13 @@ msgstr "Asebter ur yettuwelleh ara akken iwata"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Tikwal ugur-agi itekk-d seg usensi neγ tugwin n unqbal n inagan n tuqqna.</li>\n"
+"  <li>Tikwal ugur-agi itekk-d seg usensi neγ tugwin n unqbal n inagan n "
+"tuqqna.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -558,11 +606,13 @@ msgstr "Ur nessin ara tansa"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Issefk ahat ad tesbeddeḍ aseγzan-nniḍen akken ad d-ldiḍ tansa-agi.</li>\n"
+"  <li>Issefk ahat ad tesbeddeḍ aseγzan-nniḍen akken ad d-ldiḍ tansa-"
+"agi.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -572,14 +622,18 @@ msgstr "Tuqqna taγelsant ur teddi ara"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
-" <ul> <li>Ayagi yekka-d ahat seg ugur n twila n uqeddac neγ amdan yettaɛraḍen ad yakker timagit n uqeddac.</li>\n"
-"  <li>Ma yella teqqneḍ yakan ar uqeddac-agi, ahat tuccḍa d umatu kan, tzemreḍ ad tɛerḍeḍ tikelt-nniḍen ticki.</li></ul>"
+" <ul> <li>Ayagi yekka-d ahat seg ugur n twila n uqeddac neγ amdan "
+"yettaɛraḍen ad yakker timagit n uqeddac.</li>\n"
+"  <li>Ma yella teqqneḍ yakan ar uqeddac-agi, ahat tuccḍa d umatu kan, "
+"tzemreḍ ad tɛerḍeḍ tikelt-nniḍen ticki.</li></ul>"
 
 msgctxt "error_generic_title"
 msgid "Oops"
@@ -623,8 +677,12 @@ msgstr "Ldi aseɣwen deg iccer amaynut"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Tugniwin ittwaskelsen akked ittwabḍan<b>ur ttwaksent ara </b> m'ara ad tekseḍ %1$samazray."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Tugniwin ittwaskelsen akked ittwabḍan<b>ur ttwaksent ara </b> m'ara ad "
+"tekseḍ %1$samazray."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -633,8 +691,12 @@ msgstr "Rmed tabaḍnit inek"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Iminig uslig ad yali deg uswir.Dayen ur tuγaleḍ ad twaliḍ adellel neγ imsfuγal i k-ṭṭafaren u saẓayen tulya n isemal web."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Iminig uslig ad yali deg uswir.Dayen ur tuγaleḍ ad twaliḍ adellel neγ "
+"imsfuγal i k-ṭṭafaren u saẓayen tulya n isemal web."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -643,7 +705,9 @@ msgstr "Anadi-ik, abrid-ik"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "Tettnadiḍ ayen-nniḍen? Fren amsadday-nniḍen n unadi amezwer deg iɣewwaṛen."
 
 #. First run tour (Shortcut): Title
@@ -655,8 +719,12 @@ msgstr "Rnu anegzum ar ugdil-ik agejdan"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Uɣal ar yesmal-ik inurifen deg %1$s s zreb. Fren kan \"Rnu ar ugdil agejdan\" seg umuɣ %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Uɣal ar yesmal-ik inurifen deg %1$s s zreb. Fren kan \"Rnu ar ugdil "
+"agejdan\" seg umuɣ %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -667,8 +735,12 @@ msgstr "Err tabaḍnit d tanumi"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Sbadu %1$s d iminig-ik amezwar sakin faṛeṣ tagnit n tunigin tusligt ticki teldiḍ-d isebtar web seg isnasen-nniḍen."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Sbadu %1$s d iminig-ik amezwar sakin faṛeṣ tagnit n tunigin tusligt ticki"
+" teldiḍ-d isebtar web seg isnasen-nniḍen."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -706,6 +778,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Sefsex"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -721,3 +801,36 @@ msgstr "Ldi aseɣwen deg iccer yettwafernen"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Ldi"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/kk/app.po
+++ b/locales/kk/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-27 05:54+0000\n"
 "Last-Translator: Baurzhan Muftakhidinov <baurthefirst@gmail.com>\n"
-"Language-Team: kk <LL@li.org>\n"
 "Language: kk\n"
+"Language-Team: kk <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,25 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s басқаруды қолыңызға береді.</p>\n"
 "<p>Оны жекелік браузері ретінде қолданыңыз:\n"
 "  <ul>\n"
 "    <li>Қолданба ішінен тікелей іздеу және шолу</li>\n"
-"    <li>Трекерлерді блоктаңыз (немесе, оларды рұқсат ету үшін, баптауларды жаңартыңыз)</li>\n"
+"    <li>Трекерлерді блоктаңыз (немесе, оларды рұқсат ету үшін, "
+"баптауларды жаңартыңыз)</li>\n"
 "    <li>Cookies және іздеу мен шолу тарихын кетіру үшін өшіріңіз</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s жасаған Mozilla. Мақсатымыз - интернет денсаулығын және ашықтығын сақтау.<br/>\n"
+"<p>%1$s жасаған Mozilla. Мақсатымыз - интернет денсаулығын және ашықтығын"
+" сақтау.<br/>\n"
 "<a href=\"%2$s\">Көбірек білу</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +286,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Анонимды қолдану деректерін жіберіп отыру"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Көбірек білу"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +340,16 @@ msgstr "Шолу тарихын өшіру"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Жазық қылу"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +460,12 @@ msgstr "Сілтемені аша алатын қолданбаны табу"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Құрылғыңыздағы бірде-бір қолданба бұл сілтемені аша алмайды. Оны аша алатын қолданбасын %2$s ішінен іздеу үшін, сіз %1$s ішінен шыға аласыз."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Құрылғыңыздағы бірде-бір қолданба бұл сілтемені аша алмайды. Оны аша "
+"алатын қолданбасын %2$s ішінен іздеу үшін, сіз %1$s ішінен шыға аласыз."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +490,9 @@ msgstr "Ашу"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Сіз %1$s тарихын өшірген кезде жүктеліп алынған файлдар <b>өшірілмейді</b>."
+msgstr ""
+"Сіз %1$s тарихын өшірген кезде жүктеліп алынған файлдар "
+"<b>өшірілмейді</b>."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +525,17 @@ msgstr "Байланысты орнату сәтсіз аяқталды"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Сайт уақытша қолжетерсіз, немесе сұранымдарға толы шығар. Кейінірек қайталап көріңіз.</li>\n"
-"        <li>Бірде-бір сайт ашылмаса, мобильді құрылғыңыздың деректер не Wi-Fi байланысын тексеріңіз.</li>\n"
+"        <li>Сайт уақытша қолжетерсіз, немесе сұранымдарға толы шығар. "
+"Кейінірек қайталап көріңіз.</li>\n"
+"        <li>Бірде-бір сайт ашылмаса, мобильді құрылғыңыздың деректер не "
+"Wi-Fi байланысын тексеріңіз.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +552,17 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Адресті енгізген кезде қате кетпегенге көз жеткізіңіз, мысалы \n"
+"        <li>Адресті енгізген кезде қате кетпегенге көз жеткізіңіз, мысалы"
+" \n"
 "         <strong>www</strong>.example.com орнына \n"
 "         <strong>ww</strong>.example.com</li>\n"
-"        <li>Бірде-бір сайт ашылмаса, мобильді құрылғыңыздың деректер не Wi-Fi байланысын тексеріңіз.</li>\n"
+"        <li>Бірде-бір сайт ашылмаса, мобильді құрылғыңыздың деректер не "
+"Wi-Fi байланысын тексеріңіз.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +572,17 @@ msgstr "Адрес қате"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Веб адрестері әдетте келесідей жазылады - <strong>http://www.example.com/</strong></li>\n"
-"  <li>Қалыпты слэштер қолданатыңызға көз жеткізіңіз (мыс. <strong>/</strong>).</li>\n"
+"  <li>Веб адрестері әдетте келесідей жазылады - "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Қалыпты слэштер қолданатыңызға көз жеткізіңіз (мыс. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +592,13 @@ msgstr "Парақтағы бағдарлау дұрыс емес"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Бұл мәселе кейде cookies қабылдау сөндірілген кезде болуы мүмкін.</li>\n"
+"  <li>Бұл мәселе кейде cookies қабылдау сөндірілген кезде болуы "
+"мүмкін.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +608,13 @@ msgstr "Адресті талдау қатесі"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Бұл адресті ашу үшін сізге қосымша бағдарламаларды орнату керек мүмкін.</li>\n"
+"  <li>Бұл адресті ашу үшін сізге қосымша бағдарламаларды орнату керек "
+"мүмкін.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +624,19 @@ msgstr "Қауіпсіз байланысты орнату сәтсіз аяқт
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Бұл сервердің қатесі болуы мүмкін, немесе біреу сізге керек серверді басқасымен ауыстырғысы келеді.</li>\n"
-"  <li>Осыған дейін бұл серверге сәтті қосылған болсаңыз, бұл қате уақытша болуы мүмкін. Біраздан кейін қайталап көріңіз.</li>\n"
+"  <li>Бұл сервердің қатесі болуы мүмкін, немесе біреу сізге керек "
+"серверді басқасымен ауыстырғысы келеді.</li>\n"
+"  <li>Осыған дейін бұл серверге сәтті қосылған болсаңыз, бұл қате уақытша"
+" болуы мүмкін. Біраздан кейін қайталап көріңіз.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +681,12 @@ msgstr "Сілтемені жаңа бетте ашу"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "%1$s тарихы өшірілген кезде сақталған және бөліскен суреттер <b>өшірілмейді</b>."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"%1$s тарихы өшірілген кезде сақталған және бөліскен суреттер "
+"<b>өшірілмейді</b>."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +695,13 @@ msgstr "Жекелігіңізді күшейтіңіз"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Жекелік шолудың келесі деңгейіне өтіңіз. Сайттар арасында сізді бақылайтын және парақтардың жүктелу уақытын арттыратын жарнама және басқа құраманы блоктаңыз."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Жекелік шолудың келесі деңгейіне өтіңіз. Сайттар арасында сізді "
+"бақылайтын және парақтардың жүктелу уақытын арттыратын жарнама және басқа"
+" құраманы блоктаңыз."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +710,12 @@ msgstr "Сіздің іздеулеріңіз, сіздің жолыңызбен
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Басқа бірнәрсе іздедіңіз бе? Баптаулардан басқа негізгі іздеу жүйесін таңдаңыз."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Басқа бірнәрсе іздедіңіз бе? Баптаулардан басқа негізгі іздеу жүйесін "
+"таңдаңыз."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +726,12 @@ msgstr "Үй экранына жарлықтарды қосыңыз"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "%1$s ішінде таңдамалы сайттарға жылдам оралыңыз. Тек %1$s мәзірінен \"Үй экранына қосу\" таңдаңыз."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"%1$s ішінде таңдамалы сайттарға жылдам оралыңыз. Тек %1$s мәзірінен \"Үй "
+"экранына қосу\" таңдаңыз."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +742,12 @@ msgstr "Жекелікті әдет қылыңыз"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "%1$s негізгі браузер ретінде орнатып, басқа қолданбалардан вебпарақтарын ашу кезінде жекелік шолудың артықшылықтарын алыңыз."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"%1$s негізгі браузер ретінде орнатып, басқа қолданбалардан вебпарақтарын "
+"ашу кезінде жекелік шолудың артықшылықтарын алыңыз."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +785,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Бас тарту"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +808,36 @@ msgstr "Сілтемені таңдалған бетте ашу"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Ашу"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/ko/app.po
+++ b/locales/ko/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-07-13 06:58+0000\n"
 "Last-Translator: Hyeonseok Shin <hyeonseok@gmail.com>\n"
 "Language: ko\n"
@@ -284,9 +284,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "익명으로 사용 데이터 보내기"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "상세정보"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +337,16 @@ msgstr "탐색 기록 지우기"
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -733,6 +759,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr ""
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -747,5 +781,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/lo/app.po
+++ b/locales/lo/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-04 03:08+0000\n"
 "Last-Translator: Saikeo <kavhanxay@hotmail.com>\n"
 "Language: lo\n"
@@ -286,9 +286,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "ສົ່ງຂໍ້ມູນການໃຊ້ງານແບບບໍ່ລະບຸຕົວຕົນ"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "ຮຽນຮູ້ເພີ່ມເຕີມ"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -323,6 +339,16 @@ msgstr "ລຶບປະຫວັດການທ່ອງເວັບ"
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -747,6 +773,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "ຍົກເລີກ"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -761,5 +795,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/ms/app.po
+++ b/locales/ms/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-17 07:06+0000\n"
 "Last-Translator: manxmensch <manxmensch@gmail.com>\n"
-"Language-Team: ms <LL@li.org>\n"
 "Language: ms\n"
+"Language-Team: ms <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s membolehkan anda mengawal.</p>\n"
 "<p>Gunakannya sebagai pelayar peribadi:\n"
 "  <ul>\n"
 "    <li>Cari dan melayar terus dalam app</li>\n"
-"    <li>Sekat penjejak (atau kemaskini tetapan untuk izinkan penjejak)</li>\n"
-"    <li>Padam untuk menghapuskan kuki serta sejarah carian dan pelayaran</li>\n"
+"    <li>Sekat penjejak (atau kemaskini tetapan untuk izinkan "
+"penjejak)</li>\n"
+"    <li>Padam untuk menghapuskan kuki serta sejarah carian dan "
+"pelayaran</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s dihasilkan oleh Mozilla. Misi kami adalah untuk memupuk internet yang sihat dan terbuka.<br/>\n"
+"<p>%1$s dihasilkan oleh Mozilla. Misi kami adalah untuk memupuk internet "
+"yang sihat dan terbuka.<br/>\n"
 "<a href=\"%2$s\">Ketahui selanjutnya</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Hantar data penggunaan anonimus"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Ketahui selanjutnya"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Buang sejarah pelayaran"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Kembangkan"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "Cari aplikasi yang boleh buka pautan"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Tiada aplikasi pada peranti anda dapat membuka pautan ini. Anda boleh tinggalkan %1$s untuk mencari %2$s aplikasi yang boleh melaksanakannya."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Tiada aplikasi pada peranti anda dapat membuka pautan ini. Anda boleh "
+"tinggalkan %1$s untuk mencari %2$s aplikasi yang boleh melaksanakannya."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +491,9 @@ msgstr "Buka"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Fail yang dimuat turun <b>tidak akan dihapuskan</b> apabila anda padam sejarah %1$s."
+msgstr ""
+"Fail yang dimuat turun <b>tidak akan dihapuskan</b> apabila anda padam "
+"sejarah %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +526,17 @@ msgstr "Tidak dapat menyambung"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Laman ini tidak tersedia buat masa ini atau terlalu sibuk. Cuba lagi selepas beberapa saat.</li>\n"
-"        <li>Jika anda tidak dapat memuatkan sebarang halaman, semak data peranti telefon atau sambungan Wi-Fi anda.</li>\n"
+"        <li>Laman ini tidak tersedia buat masa ini atau terlalu sibuk. "
+"Cuba lagi selepas beberapa saat.</li>\n"
+"        <li>Jika anda tidak dapat memuatkan sebarang halaman, semak data "
+"peranti telefon atau sambungan Wi-Fi anda.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +553,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Semak alamat untuk kesilapan seperti\n"
 "          <strong>ww</strong>.example.com yang sepatutnya\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Jika anda tidak dapat memuat sebarang halaman, semak data peranti atau sambungan Wi-Fi anda.</li>\n"
+"        <li>Jika anda tidak dapat memuat sebarang halaman, semak data "
+"peranti atau sambungan Wi-Fi anda.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +572,17 @@ msgstr "Alamat tidak sah"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Alamat Web lazimnya ditulis begini <strong>http://www.example.com/</strong></li>\n"
-"  <li>Pastikan anda menggunakan garis miring hadapan (iaitu <strong>/</strong>).</li>\n"
+"  <li>Alamat Web lazimnya ditulis begini "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Pastikan anda menggunakan garis miring hadapan (iaitu "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +592,13 @@ msgstr "Halaman tidak diarahkan semula dengan betul"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Masalah ini kadangkala disebabkan oleh menyahdayakan atau enggan menerima kuki.</li>\n"
+"  <li>Masalah ini kadangkala disebabkan oleh menyahdayakan atau enggan "
+"menerima kuki.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +608,13 @@ msgstr "Alamat tidak difahami"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Anda mungkin perlu memasang perisian lain untuk membuka alamat ini.</li>\n"
+"  <li>Anda mungkin perlu memasang perisian lain untuk membuka alamat "
+"ini.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,16 +624,19 @@ msgstr "Sambungan selamat gagal"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
 "  <li>Ini mungkin masalah dengan konfigurasi pelayan, atau boleh jadi\n"
 "ada pihak yang cuba menyamar sebagai pelayan.</li>\n"
-"  <li>Jika anda pernah berjaya mendapatkan hubungan dengan pelayan ini dulu, ralat ini mungkin\n"
+"  <li>Jika anda pernah berjaya mendapatkan hubungan dengan pelayan ini "
+"dulu, ralat ini mungkin\n"
 "sementara dan anda boleh cuba lagi nanti.</li>\n"
 "</ul>"
 
@@ -629,8 +682,12 @@ msgstr "Buka pautan dalam tab baru"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Imej yang disimpan dan dikongsi <b>tidak akan dihapuskan</b> apabila anda padam sejarah %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Imej yang disimpan dan dikongsi <b>tidak akan dihapuskan</b> apabila anda"
+" padam sejarah %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -639,8 +696,13 @@ msgstr "Tingkatkan privasi anda"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Membawa pelayaran peribadi ke tahap seterusnya, Sekat iklan dan kandungan lain yang menjejaki anda di serata laman dan melambatkan tempoh memuatkan halaman."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Membawa pelayaran peribadi ke tahap seterusnya, Sekat iklan dan kandungan"
+" lain yang menjejaki anda di serata laman dan melambatkan tempoh "
+"memuatkan halaman."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -649,7 +711,9 @@ msgstr "Carian anda, cara anda"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "Mencari sesuatu yang berlainan? Pilih enjin piawai lain dalam Tetapan."
 
 #. First run tour (Shortcut): Title
@@ -661,8 +725,12 @@ msgstr "Letakkan pintasan dalam skrin utama"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Kembali ke laman kegemaran anda dalam %1$s dengan pantas. Hanya pilih \"Tambah ke skrin Utama\" dari dalam menu %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Kembali ke laman kegemaran anda dalam %1$s dengan pantas. Hanya pilih "
+"\"Tambah ke skrin Utama\" dari dalam menu %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -673,8 +741,13 @@ msgstr "Jadikan privasi satu tabiat"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Tetapkan %1$s sebagai pelayar piawai anda dan dapatkan manfaat daripada pelayaran peribadi apabila anda buka pautan halaman web dari aplikasi lain."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Tetapkan %1$s sebagai pelayar piawai anda dan dapatkan manfaat daripada "
+"pelayaran peribadi apabila anda buka pautan halaman web dari aplikasi "
+"lain."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -712,6 +785,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Batal"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -727,3 +808,36 @@ msgstr "Buka pautan dalam tab yang dipilih"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Buka"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/my/app.po
+++ b/locales/my/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-06-10 15:43+0000\n"
 "Last-Translator: La Min Ko (လမင်းကို) <lminko.lmk@gmail.com>\n"
 "Language: my\n"
@@ -286,9 +286,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "အမျိုးအမည်မဲ့ အသုံးပြုမှု အချက်အလက်များကို ပေးပို့ရန်"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "ပိုမိုလေ့လာရန်"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -323,6 +339,16 @@ msgstr "ကြည့်ရှုမှုမှတ်တမ်းကို ရ�
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -748,6 +774,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr ""
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -762,5 +796,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/nb-NO/app.po
+++ b/locales/nb-NO/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 16:15+0000\n"
 "Last-Translator: Håvar Henriksen <havar@firefox.no>\n"
-"Language-Team: nb_NO <LL@li.org>\n"
 "Language: nb_NO\n"
+"Language-Team: nb_NO <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s gir deg kontroll.</p>\n"
 "<p>Bruk den som en privat nettleser:\n"
 "  <ul>\n"
 "    <li>Søk og surf rett i appen</li>\n"
-"    <li>Blokker sporere (eller oppdater innstillingene for å tillate sporere)</li>\n"
-"    <li>Slett for å fjerne infokapsler samt søk- og nettleserhistorikk</li>\n"
+"    <li>Blokker sporere (eller oppdater innstillingene for å tillate "
+"sporere)</li>\n"
+"    <li>Slett for å fjerne infokapsler samt søk- og "
+"nettleserhistorikk</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s er produsert av Mozilla. Vår misjon er å fremme et sunt, åpent Internett.<br/>\n"
+"<p>%1$s er produsert av Mozilla. Vår misjon er å fremme et sunt, åpent "
+"Internett.<br/>\n"
 "<a href=\"%2$s\">Les mer</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Send anonyme brukerdata"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Les mer"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Slett nettleserhistorikk"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Fold ut"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "Finn en app som kan åpne lenken"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ingen av appene på din enhet kan åpne denne lenken. Du kan gå ut av %1$s for å søke på %2$s etter en app som kan gjøre dette."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ingen av appene på din enhet kan åpne denne lenken. Du kan gå ut av %1$s "
+"for å søke på %2$s etter en app som kan gjøre dette."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +491,9 @@ msgstr "Åpne"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Nedlastede filer <b>vil ikke bli fjernet</b> når du sletter %1$s-historikken."
+msgstr ""
+"Nedlastede filer <b>vil ikke bli fjernet</b> når du sletter "
+"%1$s-historikken."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +526,17 @@ msgstr "Kan ikke koble til"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Siden kan være midlertidig utilgjengelig, eller opptatt. Prøv igjen om en stund.</li>\n"
-"        <li>Hvis du ikke klarer å laste noen sider, kontroller data- eller Wi-Fi-forbindelsen til enheten din.</li>\n"
+"        <li>Siden kan være midlertidig utilgjengelig, eller opptatt. Prøv"
+" igjen om en stund.</li>\n"
+"        <li>Hvis du ikke klarer å laste noen sider, kontroller data- "
+"eller Wi-Fi-forbindelsen til enheten din.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +553,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Kontroller om det er skrivefeil i adressen, for eksempel\n"
 "          <strong>ww</strong>.eksempel.no istedenfor \n"
 "          <strong>www</strong>.eksempel.no</li>\n"
-"        <li>Hvis du ikke klarer å laste noen nettsider, kontroller data- eller Wi-Fi-forbindelsen til enheten din.</li>\n"
+"        <li>Hvis du ikke klarer å laste noen nettsider, kontroller data- "
+"eller Wi-Fi-forbindelsen til enheten din.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +572,17 @@ msgstr "Adressen er ugyldig"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Nettadresser skrives vanligvis som <strong>http://www.example.com/</strong></li>\n"
-"  <li>Pass på at du bruker vanlig skråstrek (dvs. <strong>/</strong>).</li>\n"
+"  <li>Nettadresser skrives vanligvis som "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Pass på at du bruker vanlig skråstrek (dvs. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +592,13 @@ msgstr "Nettsiden videresender ikke ordentlig"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Dette problemet kan av og til skyldes at infokapsler er avslått eller ved å ikke godta infokapsler.</li>\n"
+"  <li>Dette problemet kan av og til skyldes at infokapsler er avslått "
+"eller ved å ikke godta infokapsler.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +608,13 @@ msgstr "Klarte ikke forstå adressen"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Du må kanskje installere annen programvare for å åpne denne adressen.</li>\n"
+"  <li>Du må kanskje installere annen programvare for å åpne denne "
+"adressen.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +624,20 @@ msgstr "Sikker tilkobling mislyktes"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Dette kan være på grunn av et problem med serverens konfigurasjon, eller det kan være fordi noen forsøker å forfalske tilkoblingen til serveren.</li>\n"
-"  <li>Dersom du har klart å koble til serveren tidligere kan problemet være midlertidig, og du kan prøve igjen senere.</li>\n"
+"  <li>Dette kan være på grunn av et problem med serverens konfigurasjon, "
+"eller det kan være fordi noen forsøker å forfalske tilkoblingen til "
+"serveren.</li>\n"
+"  <li>Dersom du har klart å koble til serveren tidligere kan problemet "
+"være midlertidig, og du kan prøve igjen senere.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +682,12 @@ msgstr "Åpne lenke i ny fane"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Lagrede og delte bilder <b>vil ikke bli fjernet</b> når du sletter %1$s-historikken."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Lagrede og delte bilder <b>vil ikke bli fjernet</b> når du sletter "
+"%1$s-historikken."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +696,13 @@ msgstr "Styrk personvernet ditt"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Ta privat nettlesing til neste nivå. Blokker annonser og annet innhold som kan spore deg på tvers av nettsteder og som kan gjøre nedlasting av nettsider tregere."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Ta privat nettlesing til neste nivå. Blokker annonser og annet innhold "
+"som kan spore deg på tvers av nettsteder og som kan gjøre nedlasting av "
+"nettsider tregere."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +711,12 @@ msgstr "Ditt søk på din måte"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Søker du etter noe annet? Velg en annen standard søkemotor i innstillinger."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Søker du etter noe annet? Velg en annen standard søkemotor i "
+"innstillinger."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +727,12 @@ msgstr "Legg til snarveier på startskjermen"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Gå raskt tilbake til favorittnettstedene dine i %1$s. Velg «Legg til på startskjermen» fra %1$s-menyen."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Gå raskt tilbake til favorittnettstedene dine i %1$s. Velg «Legg til på "
+"startskjermen» fra %1$s-menyen."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +743,12 @@ msgstr "Gjør personvern til en vane"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Velg %1$s som standardnettleser, og få fordelene med privat nettlesing når du åpner nettsider fra andre apper."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Velg %1$s som standardnettleser, og få fordelene med privat nettlesing "
+"når du åpner nettsider fra andre apper."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +786,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Avbryt"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +809,36 @@ msgstr "Åpne lenke i valgt fane"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Åpne"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/ne-NP/app.po
+++ b/locales/ne-NP/app.po
@@ -6,17 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-18 14:58+0000\n"
 "Last-Translator: roosan.gm <roosan.gm@gmail.com>\n"
-"Language-Team: ne <LL@li.org>\n"
 "Language: ne_NP\n"
+"Language-Team: ne <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -166,10 +165,12 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 
@@ -271,8 +272,24 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr ""
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
+msgstr ""
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
 msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
@@ -308,6 +325,16 @@ msgstr ""
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -419,7 +446,9 @@ msgstr ""
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
 msgstr ""
 
 #. This label is shown above a list of apps that can be used to open a given
@@ -478,8 +507,10 @@ msgstr ""
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 
@@ -497,7 +528,8 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 
@@ -508,8 +540,10 @@ msgstr ""
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 
@@ -520,7 +554,8 @@ msgstr ""
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 
@@ -531,7 +566,8 @@ msgstr ""
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 
@@ -542,9 +578,11 @@ msgstr ""
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
@@ -591,7 +629,9 @@ msgstr ""
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
 msgstr ""
 
 #. First run tour (Default browser): Title
@@ -601,7 +641,9 @@ msgstr ""
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
 msgstr ""
 
 #. First run tour (Search): Title
@@ -611,7 +653,9 @@ msgstr ""
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr ""
 
 #. First run tour (Shortcut): Title
@@ -623,7 +667,9 @@ msgstr ""
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
 msgstr ""
 
 #. First run tour (Privacy): Title
@@ -635,7 +681,9 @@ msgstr ""
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
 msgstr ""
 
 msgctxt "firstrun_close_button"
@@ -674,6 +722,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr ""
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -689,3 +745,36 @@ msgstr ""
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/nl/app.po
+++ b/locales/nl/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-18 09:52+0000\n"
 "Last-Translator: Ton <tonnes.mb@gmail.com>\n"
-"Language-Team: nl <LL@li.org>\n"
 "Language: nl\n"
+"Language-Team: nl <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 1)) && ((0 == 0))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s geeft u de controle.</p>\n"
 "<p>Gebruik als een privébrowser:\n"
 "  <ul>\n"
 "    <li>Rechtstreeks vanuit de app zoeken en browsen</li>\n"
-"    <li>Trackers blokkeren (of instellingen bijwerken om ze toe te staan)</li>\n"
-"    <li>Wissen verwijdert zowel cookies als zoek- en navigatiegeschiedenis</li>\n"
+"    <li>Trackers blokkeren (of instellingen bijwerken om ze toe te "
+"staan)</li>\n"
+"    <li>Wissen verwijdert zowel cookies als zoek- en "
+"navigatiegeschiedenis</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s wordt gemaakt door Mozilla. Onze missie is het verzorgen van een gezond en open internet.<br/>\n"
+"<p>%1$s wordt gemaakt door Mozilla. Onze missie is het verzorgen van een "
+"gezond en open internet.<br/>\n"
 "<a href=\"%2$s\">Meer info</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Anonieme gebruiksgegevens verzenden"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Meer info"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Navigatiegeschiedenis wissen"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Uitvouwen"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "Een app zoeken die de koppeling kan openen"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Geen enkele app op uw apparaat kan deze koppeling openen. U kunt %1$s verlaten om bij %2$s naar een app te zoeken die dat wel kan."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Geen enkele app op uw apparaat kan deze koppeling openen. U kunt %1$s "
+"verlaten om bij %2$s naar een app te zoeken die dat wel kan."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +491,9 @@ msgstr "Openen"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Gedownloade bestanden <b>worden niet verwijderd</b> als u geschiedenis van %1$s wist."
+msgstr ""
+"Gedownloade bestanden <b>worden niet verwijderd</b> als u geschiedenis "
+"van %1$s wist."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +526,17 @@ msgstr "Kan geen verbinding maken"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Misschien is de website tijdelijk niet beschikbaar of overbelast. Probeer het over enkele ogenblikken opnieuw.</li>\n"
-"        <li>Als u geen enkele pagina kunt laden, controleer dan de gegevens- of wifi-verbinding van uw apparaat.</li>\n"
+"        <li>Misschien is de website tijdelijk niet beschikbaar of "
+"overbelast. Probeer het over enkele ogenblikken opnieuw.</li>\n"
+"        <li>Als u geen enkele pagina kunt laden, controleer dan de "
+"gegevens- of wifi-verbinding van uw apparaat.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +553,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Controleer het adres op typefouten, zoals\n"
 "          <strong>ww</strong>.example.com in plaats van\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Als u geen enkele pagina kunt laden, controleer dan de gegevens- of wifi-verbinding van uw apparaat.</li>\n"
+"        <li>Als u geen enkele pagina kunt laden, controleer dan de "
+"gegevens- of wifi-verbinding van uw apparaat.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +572,17 @@ msgstr "Het adres is niet geldig"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Webadressen worden doorgaans geschreven als <strong>http://www.example.com/</strong></li>\n"
-"  <li>Let erop dat u voorwaartse slashes gebruikt (d.i. <strong>/</strong>).</li>\n"
+"  <li>Webadressen worden doorgaans geschreven als "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Let erop dat u voorwaartse slashes gebruikt (d.i. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +592,13 @@ msgstr "De pagina verwijst niet op een juiste manier door"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Dit probleem kan soms worden veroorzaakt door het uitschakelen of weigeren van cookies.</li>\n"
+"  <li>Dit probleem kan soms worden veroorzaakt door het uitschakelen of "
+"weigeren van cookies.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +608,13 @@ msgstr "Het adres werd niet begrepen"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Misschien moet u andere software installeren om dit adres te openen.</li>\n"
+"  <li>Misschien moet u andere software installeren om dit adres te "
+"openen.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,17 +624,22 @@ msgstr "Beveiligde verbinding mislukt"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Dit kan een probleem met de serverconfiguratie zijn, of iemand probeert\n"
+"  <li>Dit kan een probleem met de serverconfiguratie zijn, of iemand "
+"probeert\n"
 "de server na te bootsen.</li>\n"
-"  <li>Als u in het verleden met succes verbinding met deze server hebt gemaakt,\n"
-"kan de fout van tijdelijke aard zijn en kunt u het later nogmaals proberen.</li>\n"
+"  <li>Als u in het verleden met succes verbinding met deze server hebt "
+"gemaakt,\n"
+"kan de fout van tijdelijke aard zijn en kunt u het later nogmaals "
+"proberen.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -629,8 +684,12 @@ msgstr "Koppeling openen in nieuw tabblad"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Opgeslagen en gedeelde afbeeldingen <b>worden niet verwijderd</b> als u geschiedenis van %1$s wist."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Opgeslagen en gedeelde afbeeldingen <b>worden niet verwijderd</b> als u "
+"geschiedenis van %1$s wist."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -639,8 +698,13 @@ msgstr "Vergroot uw privacy"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Breng privénavigatie naar een hoger niveau. Blokkeer advertenties en andere inhoud die u op websites kunnen volgen en laadtijden van pagina’s verlengen."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Breng privénavigatie naar een hoger niveau. Blokkeer advertenties en "
+"andere inhoud die u op websites kunnen volgen en laadtijden van pagina’s "
+"verlengen."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -649,8 +713,12 @@ msgstr "Zoeken op uw manier"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Op zoek naar iets anders? Kies een andere standaardzoekmachine in Instellingen."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Op zoek naar iets anders? Kies een andere standaardzoekmachine in "
+"Instellingen."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -661,8 +729,12 @@ msgstr "Voeg koppelingen toe aan uw startscherm"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Keer snel terug naar uw favoriete websites in %1$s. Selecteer gewoon ‘Toevoegen aan startscherm’ vanuit het %1$s-menu."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Keer snel terug naar uw favoriete websites in %1$s. Selecteer gewoon "
+"‘Toevoegen aan startscherm’ vanuit het %1$s-menu."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -673,8 +745,12 @@ msgstr "Maak privacy een gewoonte"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Stel %1$s in als uw standaardbrowser en ervaar de voordelen van privénavigatie als u webpagina’s opent vanuit andere apps."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Stel %1$s in als uw standaardbrowser en ervaar de voordelen van "
+"privénavigatie als u webpagina’s opent vanuit andere apps."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -712,6 +788,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Annuleren"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -727,3 +811,36 @@ msgstr "Koppeling openen in geselecteerde tabblad"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Openen"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/nn-NO/app.po
+++ b/locales/nn-NO/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 18:58+0000\n"
 "Last-Translator: Bjørn I. <bjorn.svindseth@online.no>\n"
-"Language-Team: nn_NO <LL@li.org>\n"
 "Language: nn_NO\n"
+"Language-Team: nn_NO <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s gir deg kontroll.</p>\n"
 "<p>Bruk han som ein privat nettlesar:\n"
 "  <ul>\n"
 "    <li>Søk og surf rett i appen</li>\n"
-"    <li>Blokker sporarar (eller oppdater innstillingane for å tillate sporarar)</li>\n"
-"    <li>Slett for å fjerne infokapslar samt søk- og nettlesarhistorikk</li>\n"
+"    <li>Blokker sporarar (eller oppdater innstillingane for å tillate "
+"sporarar)</li>\n"
+"    <li>Slett for å fjerne infokapslar samt søk- og "
+"nettlesarhistorikk</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s er produsert av Mozilla. Vår misjon er å fremme eit sunt, ope Internett.<br/>\n"
+"<p>%1$s er produsert av Mozilla. Vår misjon er å fremme eit sunt, ope "
+"Internett.<br/>\n"
 "<a href=\"%2$s\">Les meir</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Send anonyme brukardata"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Les meir"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +341,16 @@ msgstr "Slett nettlesarhistorikk"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Fald ut"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +461,12 @@ msgstr "Finn ein app som kan opne lenka"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ingen av appane på eininga di kan opne denne lenka. Du kan gå ut av %1$s for å søke på %2$s etter ein app som kan gjere dette."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ingen av appane på eininga di kan opne denne lenka. Du kan gå ut av %1$s "
+"for å søke på %2$s etter ein app som kan gjere dette."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +491,9 @@ msgstr "Opne"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Nedlasta filer <b>vil ikkje bli fjerna</b> når du slettar %1$s-historikken."
+msgstr ""
+"Nedlasta filer <b>vil ikkje bli fjerna</b> når du slettar "
+"%1$s-historikken."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +526,17 @@ msgstr "Kan ikkje kople til"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Sida kan vere mellombels utilgjengeleg, eller opptatt. Prøv igjen om ei stund.</li>\n"
-"        <li>Viss du ikkje klarer å laste nokre sider, kontroller data- eller Wi-Fi-sambandet til eininga di.</li>\n"
+"        <li>Sida kan vere mellombels utilgjengeleg, eller opptatt. Prøv "
+"igjen om ei stund.</li>\n"
+"        <li>Viss du ikkje klarer å laste nokre sider, kontroller data- "
+"eller Wi-Fi-sambandet til eininga di.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +553,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Kontroller om det er skrivefeil i adressa, for eksempel\n"
 "          <strong>ww</strong>.eksempel.no i staden for \n"
 "          <strong>www</strong>.eksempel.no</li>\n"
-"        <li>Viss du ikkje klarer å laste nokre nettsider, kontroller data- eller Wi-Fi-sambandet til eininga di.</li>\n"
+"        <li>Viss du ikkje klarer å laste nokre nettsider, kontroller "
+"data- eller Wi-Fi-sambandet til eininga di.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +572,17 @@ msgstr "Adressa er ikkje gyldig"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Nettadresser skriv ein vanlegvis som <strong>http://www.example.com/</strong></li>\n"
-"  <li>Pass på at du brukar vanleg skråstrek (dvs. <strong>/</strong>).</li>\n"
+"  <li>Nettadresser skriv ein vanlegvis som "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Pass på at du brukar vanleg skråstrek (dvs. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +592,13 @@ msgstr "Nettsida vidaresender ikkje korrekt"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Dette problemet kan av og til skyldast at infokapslar er avslått eller ved å ikkje godta infokapslar.</li>\n"
+"  <li>Dette problemet kan av og til skyldast at infokapslar er avslått "
+"eller ved å ikkje godta infokapslar.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +608,13 @@ msgstr "Klarte ikkje å forstå adressa"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Du må kanskje installere anna programvare for å opne denne adressa.</li>\n"
+"  <li>Du må kanskje installere anna programvare for å opne denne "
+"adressa.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +624,20 @@ msgstr "Sikker tilkopling feila"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Dette kan vere på grunn av eit problem med serverkonfigurasjonen, eller det kan vere fordi nokon prøver å forfalske tilkoplinga til serveren.</li>\n"
-"  <li>Dersom du har klart å kople til serveren tidlegare, kan problemet vere mellombels og du kan prøve igjen seinare.</li>\n"
+"  <li>Dette kan vere på grunn av eit problem med serverkonfigurasjonen, "
+"eller det kan vere fordi nokon prøver å forfalske tilkoplinga til "
+"serveren.</li>\n"
+"  <li>Dersom du har klart å kople til serveren tidlegare, kan problemet "
+"vere mellombels og du kan prøve igjen seinare.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +682,12 @@ msgstr "Opne lenke i ny fane"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Lagra og delte bilde <b>vil ikkje bli fjerna</b> når du slettar %1$s-historikken."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Lagra og delte bilde <b>vil ikkje bli fjerna</b> når du slettar "
+"%1$s-historikken."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +696,13 @@ msgstr "Styrk personvernet ditt"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Ta privat nettlesing til neste nivå. Blokker annonsar og anna innhald som kan spore deg på tvers av nettstadar og som kan gjere nedlasting av nettsider tregare."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Ta privat nettlesing til neste nivå. Blokker annonsar og anna innhald som"
+" kan spore deg på tvers av nettstadar og som kan gjere nedlasting av "
+"nettsider tregare."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +711,12 @@ msgstr "Ditt søk på din måte"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Søkjer du etter noko anna? Vel ein annan standard-søkjemotor i innstillingar."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Søkjer du etter noko anna? Vel ein annan standard-søkjemotor i "
+"innstillingar."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +727,12 @@ msgstr "Legg til snarvegar på startskjermen"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Gå raskt tilbake til favorittnettstadane dine i %1$s. Vel «Legg til på startskjermen» frå %1$s-menyen."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Gå raskt tilbake til favorittnettstadane dine i %1$s. Vel «Legg til på "
+"startskjermen» frå %1$s-menyen."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +743,12 @@ msgstr "Gjer personvern til ein vane"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Vel %1$s som standardnettleser, og få fordelane med privat nettlesing når du opnar nettsider frå andre apper."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Vel %1$s som standardnettleser, og få fordelane med privat nettlesing når"
+" du opnar nettsider frå andre apper."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +786,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Avbryt"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +809,36 @@ msgstr "Opne lenke i vald fane"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Opne"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/pl/app.po
+++ b/locales/pl/app.po
@@ -4,22 +4,26 @@
 # project.
 # Piotr Drąg <piotrdrag@gmail.com>, 2017.
 # Aviary.pl <community-poland@mozilla.org>, 2017.
-# 
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: focus-android\n"
+"Project-Id-Version:  focus-android\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-22 23:02+0000\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
-"Language-Team: Polish <community-poland@mozilla.org>\n"
 "Language: pl\n"
+"Language-Team: Polish <community-poland@mozilla.org>\n"
+"Plural-Forms: nplurals=4; plural=(((((0 == 0)) && (((n % 10) >= 2 && (n %"
+" 10) <= 4))) && (!(((n % 100) >= 12 && (n % 100) <= 14)))) ? 1 : ((((((0 "
+"== 0)) && (!((n == 1)))) && (((n % 10) >= 0 && (n % 10) <= 1))) || (((0 "
+"== 0)) && (((n % 10) >= 5 && (n % 10) <= 9)))) || (((0 == 0)) && (((n % "
+"100) >= 12 && (n % 100) <= 14)))) ? 2 : (((n == 1)) && ((0 == 0))) ? 0 : "
+"3)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -169,10 +173,12 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s daje większą kontrolę.</p>\n"
@@ -180,10 +186,12 @@ msgstr ""
 "  <ul>\n"
 "    <li>wyszukiwanie i przeglądanie prosto z aplikacji</li>\n"
 "    <li>blokowanie śledzenia (można to zmienić w ustawieniach)</li>\n"
-"    <li>usuwanie ciasteczek oraz całej historii wyszukiwania i przeglądania</li>\n"
+"    <li>usuwanie ciasteczek oraz całej historii wyszukiwania "
+"i przeglądania</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s jest tworzony przez Mozillę. Naszym celem jest wspieranie zdrowego i otwartego Internetu.<br/>\n"
+"<p>%1$s jest tworzony przez Mozillę. Naszym celem jest wspieranie "
+"zdrowego i otwartego Internetu.<br/>\n"
 "<a href=\"%2$s\">Więcej informacji</a></p>"
 
 msgctxt "preference_category_search"
@@ -284,9 +292,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Przesyłanie anonimowych danych o użyciu"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Więcej informacji"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -322,6 +346,16 @@ msgstr "Usuń historię przeglądania"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Rozwiń"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -432,8 +466,12 @@ msgstr "Wyszukiwanie aplikacji mogącej otworzyć odnośnik"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Żadna aplikacja na urządzeniu nie może otworzyć tego odnośnika. Można wyjść z aplikacji %1$s, aby wyszukać odpowiednią aplikację w „%2$s”."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Żadna aplikacja na urządzeniu nie może otworzyć tego odnośnika. Można "
+"wyjść z aplikacji %1$s, aby wyszukać odpowiednią aplikację w „%2$s”."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -458,7 +496,9 @@ msgstr "Otwórz"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Pobrane pliki <b>nie zostaną usunięte</b> po wyczyszczeniu historii programu %1$s."
+msgstr ""
+"Pobrane pliki <b>nie zostaną usunięte</b> po wyczyszczeniu historii "
+"programu %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -491,13 +531,17 @@ msgstr "Nie można połączyć"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Strona może być tymczasowo niedostępna lub przeciążona. Spróbuj ponownie za chwilę.</li>\n"
-"        <li>Jeśli nie możesz otworzyć żadnej strony, sprawdź swoje połączenie z Internetem.</li>\n"
+"        <li>Strona może być tymczasowo niedostępna lub przeciążona. "
+"Spróbuj ponownie za chwilę.</li>\n"
+"        <li>Jeśli nie możesz otworzyć żadnej strony, sprawdź swoje "
+"połączenie z Internetem.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -514,14 +558,17 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Upewnij się, że wpisany adres nie zawiera takich literówek, jak\n"
+"        <li>Upewnij się, że wpisany adres nie zawiera takich literówek, "
+"jak\n"
 "          <strong>ww</strong>.mozilla.org zamiast\n"
 "          <strong>www</strong>.mozilla.org</li>\n"
-"        <li>Jeśli nie możesz otworzyć żadnej strony, sprawdź swoje połączenie z Internetem.</li>\n"
+"        <li>Jeśli nie możesz otworzyć żadnej strony, sprawdź swoje "
+"połączenie z Internetem.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -531,13 +578,17 @@ msgstr "Adres jest nieprawidłowy"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Adresy internetowe są zwykle postaci <strong>http://www.mozilla.org/</strong></li>\n"
-"  <li>Upewnij się, że adres zawiera prawidłowe ukośniki (tzn. <strong>/</strong>).</li>\n"
+"  <li>Adresy internetowe są zwykle postaci "
+"<strong>http://www.mozilla.org/</strong></li>\n"
+"  <li>Upewnij się, że adres zawiera prawidłowe ukośniki (tzn. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -547,11 +598,13 @@ msgstr "Nieprawidłowe przekierowanie strony"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Może to być spowodowane wyłączeniem lub odrzucaniem ciasteczek.</li>\n"
+"  <li>Może to być spowodowane wyłączeniem lub odrzucaniem "
+"ciasteczek.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -561,11 +614,13 @@ msgstr "Nieznany protokół"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Aby otworzyć ten adres, może być konieczna instalacja innego programu.</li>\n"
+"  <li>Aby otworzyć ten adres, może być konieczna instalacja innego "
+"programu.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -575,16 +630,19 @@ msgstr "Bezpieczne połączenie się nie powiodło"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
 "  <li>Może to być problem konfiguracji serwera lub próba podania się\n"
 "za ten serwer przez podmiot nieuprawniony.</li>\n"
-"  <li>Jeśli łączono się wcześniej z tym serwerem, błąd może być tymczasowy\n"
+"  <li>Jeśli łączono się wcześniej z tym serwerem, błąd może być "
+"tymczasowy\n"
 "i należy spróbować ponownie później.</li>\n"
 "</ul>"
 
@@ -630,8 +688,12 @@ msgstr "Otwórz odnośnik w nowej karcie"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Zapisane i udostępnione obrazy <b>nie zostaną usunięte</b> po wyczyszczeniu historii programu %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Zapisane i udostępnione obrazy <b>nie zostaną usunięte</b> po "
+"wyczyszczeniu historii programu %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -640,8 +702,12 @@ msgstr "Nowy poziom prywatności"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Przejdź na wyższy poziom prywatności. Blokuj reklamy i inne elementy mogące Cię śledzić między stronami i wydłużające wczytywanie się stron."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Przejdź na wyższy poziom prywatności. Blokuj reklamy i inne elementy "
+"mogące Cię śledzić między stronami i wydłużające wczytywanie się stron."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -650,7 +716,9 @@ msgstr "Wyszukuj po swojemu"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "Szukasz czegoś innego? Wybierz inną domyślną wyszukiwarkę w ustawieniach."
 
 #. First run tour (Shortcut): Title
@@ -662,8 +730,12 @@ msgstr "Dodawaj skróty do ekranu głównego"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Szybko wracaj do ulubionych stron w programie %1$s. Po prostu wybierz „Dodaj do ekranu głównego” z menu programu %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Szybko wracaj do ulubionych stron w programie %1$s. Po prostu wybierz "
+"„Dodaj do ekranu głównego” z menu programu %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -674,8 +746,12 @@ msgstr "Prywatność na co dzień"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Ustaw %1$s jako domyślną przeglądarkę i korzystaj z zalet przeglądania prywatnego podczas otwierania stron z innych aplikacji."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Ustaw %1$s jako domyślną przeglądarkę i korzystaj z zalet przeglądania "
+"prywatnego podczas otwierania stron z innych aplikacji."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -713,6 +789,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Anuluj"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -728,3 +812,36 @@ msgstr "Otwórz odnośnik w wybranej karcie"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Otwórz"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/pt-BR/app.po
+++ b/locales/pt-BR/app.po
@@ -2,23 +2,23 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 20:42+0000\n"
 "Last-Translator: Maykon Chagas <mchagas@riseup.net>\n"
-"Language-Team: pt_BR <LL@li.org>\n"
 "Language: pt_BR\n"
+"Language-Team: pt_BR <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n >= 0 && n <= 2)) && (!((n == 2))))"
+" ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +168,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s coloca você no controle.</p>\n"
 "<p>Use-o como o seu navegador privativo:\n"
 "  <ul>\n"
 "    <li>Pesquise e navegue direto no aplicativo</li>\n"
-"    <li>Bloqueie rastreadores (ou atualize as configurações para permiti-los)</li>\n"
-"    <li>Apague para excluir cookies assim como o histórico de pesquisa e navegação</li>\n"
+"    <li>Bloqueie rastreadores (ou atualize as configurações para permiti-"
+"los)</li>\n"
+"    <li>Apague para excluir cookies assim como o histórico de pesquisa e "
+"navegação</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s é produzido pela Mozilla. Nossa missão é promover uma Internet saudável e aberta.<br/>\n"
+"<p>%1$s é produzido pela Mozilla. Nossa missão é promover uma Internet "
+"saudável e aberta.<br/>\n"
 "<a href=\"%2$s\">Saiba mais</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +288,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Enviar dados de uso anonimamente"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Saiba mais"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +342,16 @@ msgstr "Apagar o histórico de navegação"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Expandir"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +462,12 @@ msgstr "Encontrar um app que pode abrir o link"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Nenhum aplicativo do seu dispositivo consegue abrir este link. Você pode sair do %1$s para pesquisar no %2$s por um aplicativo compatível."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Nenhum aplicativo do seu dispositivo consegue abrir este link. Você pode "
+"sair do %1$s para pesquisar no %2$s por um aplicativo compatível."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +492,9 @@ msgstr "Abrir"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Arquivos baixados <b>não serão deletados</b> quando você apagar o histórico do %1$s."
+msgstr ""
+"Arquivos baixados <b>não serão deletados</b> quando você apagar o "
+"histórico do %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +527,17 @@ msgstr "Não foi possível conectar"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>O site pode estar temporariamente indisponível ou ocupado demais. Tente novamente em alguns instantes.</li>\n"
-"        <li>Se não conseguir carregar nenhuma página, verifique a conexão de dados ou Wi-Fi do seu dispositivo móvel.</li>\n"
+"        <li>O site pode estar temporariamente indisponível ou ocupado "
+"demais. Tente novamente em alguns instantes.</li>\n"
+"        <li>Se não conseguir carregar nenhuma página, verifique a conexão"
+" de dados ou Wi-Fi do seu dispositivo móvel.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +554,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Verifique se o endereço contém erros de digitação, como\n"
 "          <strong>ww</strong>.example.com ao invés de\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Se não conseguir carregar nenhuma página, verifique a conexão de dados ou Wi-Fi de seu dispositivo.</li>\n"
+"        <li>Se não conseguir carregar nenhuma página, verifique a conexão"
+" de dados ou Wi-Fi de seu dispositivo.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +573,17 @@ msgstr "O endereço não é válido"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Os endereços da Web são geralmente escritos como <strong>http://www.example.com/</strong></li>\n"
-"  <li>Certifique-se de usar barras oblíquas (ex. <strong>/</strong>).</li>\n"
+"  <li>Os endereços da Web são geralmente escritos como "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Certifique-se de usar barras oblíquas (ex. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +593,13 @@ msgstr "A página não está sendo redirecionada corretamente"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Este problema, às vezes, pode ser causado pela desativação ou recusa em aceitar os cookies.</li>\n"
+"  <li>Este problema, às vezes, pode ser causado pela desativação ou "
+"recusa em aceitar os cookies.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +609,13 @@ msgstr "O endereço não foi compreendido"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Talvez seja necessário instalar outro software para abrir esse endereço.</li>\n"
+"  <li>Talvez seja necessário instalar outro software para abrir esse "
+"endereço.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +625,19 @@ msgstr "Falha na conexão segura"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Isto pode ser um problema com a configuração do servidor ou pode ser alguém tentando se passar pelo servidor.</li>\n"
-"  <li>Se você se conectou a este servidor com sucesso no passado, o erro pode ser temporário, e você pode tentar novamente mais tarde.</li>\n"
+"  <li>Isto pode ser um problema com a configuração do servidor ou pode "
+"ser alguém tentando se passar pelo servidor.</li>\n"
+"  <li>Se você se conectou a este servidor com sucesso no passado, o erro "
+"pode ser temporário, e você pode tentar novamente mais tarde.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +682,12 @@ msgstr "Abrir link em nova aba"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "As imagens salvas e compartilhadas <b>não serão excluídas</b> ao apagar o histórico do %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"As imagens salvas e compartilhadas <b>não serão excluídas</b> ao apagar o"
+" histórico do %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +696,13 @@ msgstr "Potencialize sua privacidade"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Leve a navegação privativa ao próximo nível. Bloqueie propagandas e outros conteúdos que podem rastrear você entre os sites diminuir o tempo de carregamento das páginas."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Leve a navegação privativa ao próximo nível. Bloqueie propagandas e "
+"outros conteúdos que podem rastrear você entre os sites diminuir o tempo "
+"de carregamento das páginas."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +711,12 @@ msgstr "Pesquise à sua maneira"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Procurando algo diferente? Escolha outro mecanismo de busca padrão em Configurações."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Procurando algo diferente? Escolha outro mecanismo de busca padrão em "
+"Configurações."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +727,12 @@ msgstr "Adicione atalhos na sua tela principal"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Volte ao seus sites favoritos no %1$s rapidamente. Apenas selecione \"Adicionar à Tela principal\" pelo menu do %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Volte ao seus sites favoritos no %1$s rapidamente. Apenas selecione "
+"\"Adicionar à Tela principal\" pelo menu do %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +743,12 @@ msgstr "Faça da privacidade um hábito"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Defina o %1$s como seu navegador padrão e obtenha os benefícios da navegação privativa quando abrir páginas de outros aplicativos Android."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Defina o %1$s como seu navegador padrão e obtenha os benefícios da "
+"navegação privativa quando abrir páginas de outros aplicativos Android."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +786,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Cancelar"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +809,36 @@ msgstr "Abrir link na aba selecionada"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Abrir"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/ro/app.po
+++ b/locales/ro/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-06-10 20:16+0000\n"
 "Last-Translator: Cristian Silaghi <cristian.silaghi@mozilla.ro>\n"
 "Language: ro\n"
@@ -289,9 +289,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Trimite date anonime de utilizare"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Află mai multe"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -326,6 +342,16 @@ msgstr "Șterge istoricul de navigare"
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -751,6 +777,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr ""
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -765,5 +799,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/ru/app.po
+++ b/locales/ru/app.po
@@ -2,23 +2,27 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-19 17:48+0000\n"
 "Last-Translator: Alexander Slovesnik <unghost@mozilla-russia.org>\n"
-"Language-Team: ru <LL@li.org>\n"
 "Language: ru\n"
+"Language-Team: ru <LL@li.org>\n"
+"Plural-Forms: nplurals=4; plural=(((((0 == 0)) && (((n % 10) >= 2 && (n %"
+" 10) <= 4))) && (!(((n % 100) >= 12 && (n % 100) <= 14)))) ? 1 : (((((0 "
+"== 0)) && (((n % 10) == 0))) || (((0 == 0)) && (((n % 10) >= 5 && (n % "
+"10) <= 9)))) || (((0 == 0)) && (((n % 100) >= 11 && (n % 100) <= 14)))) ?"
+" 2 : ((((0 == 0)) && (((n % 10) == 1))) && (!(((n % 100) == 11)))) ? 0 : "
+"3)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +172,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s даёт вам контроль.</p>\n"
 "<p>Используйте его как приватный браузер:\n"
 "  <ul>\n"
 "    <li>Ищите и занимайтесь веб-сёрфингом</li>\n"
-"    <li>Блокируйте трекеры (или измените настройки, чтобы разрешить их)</li>\n"
-"    <li>Стирайте и удаляйте куки, а также историю поиска и просмотра</li>\n"
+"    <li>Блокируйте трекеры (или измените настройки, чтобы разрешить "
+"их)</li>\n"
+"    <li>Стирайте и удаляйте куки, а также историю поиска и просмотра</li>"
+"\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s создан Mozilla. Наша миссия — способствовать здоровому, открытому Интернету.<br/>\n"
+"<p>%1$s создан Mozilla. Наша миссия — способствовать здоровому, открытому"
+" Интернету.<br/>\n"
 "<a href=\"%2$s\">Узнать больше</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +292,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Отправлять анонимные данные об использовании"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Подробнее"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +346,16 @@ msgstr "Удалить историю веб-сёрфинга"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Развернуть"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +466,12 @@ msgstr "Найдите приложение, которое может откр�
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ни одно из приложений на вашем устройстве не может открыть эту ссылку. Вы можете выйти из %1$s для поиска подходящего приложения в %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ни одно из приложений на вашем устройстве не может открыть эту ссылку. Вы"
+" можете выйти из %1$s для поиска подходящего приложения в %2$s."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -490,13 +529,17 @@ msgstr "Не удалось подключиться"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Возможно, сайт временно недоступен или перегружен запросами. Подождите некоторое время и попробуйте снова.</li>\n"
-"        <li>Если ни одна страница не загружается, проверьте соединение вашего устройства с мобильной или Wi-Fi сетью.</li>\n"
+"        <li>Возможно, сайт временно недоступен или перегружен запросами. "
+"Подождите некоторое время и попробуйте снова.</li>\n"
+"        <li>Если ни одна страница не загружается, проверьте соединение "
+"вашего устройства с мобильной или Wi-Fi сетью.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +556,17 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Проверьте, не допущена ли ошибка при наборе адреса, например,\n"
+"        <li>Проверьте, не допущена ли ошибка при наборе адреса, например,"
+"\n"
 "          <strong>ww</strong>.test.ru вместо\n"
 "          <strong>www</strong>.test.ru</li>\n"
-"        <li>Если ни одна страница не загружается, проверьте соединение вашего устройства с мобильной или Wi-Fi сетью.</li>\n"
+"        <li>Если ни одна страница не загружается, проверьте соединение "
+"вашего устройства с мобильной или Wi-Fi сетью.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +576,17 @@ msgstr "Формат адреса неверен"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Адреса веб-сайтов обычно записываются в формате <strong>http://www.test.ru/</strong></li>\n"
-"  <li>Убедитесь, что вы используете слеши (например, <strong>/</strong>).</li>\n"
+"  <li>Адреса веб-сайтов обычно записываются в формате "
+"<strong>http://www.test.ru/</strong></li>\n"
+"  <li>Убедитесь, что вы используете слеши (например, "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +596,13 @@ msgstr "Циклическое перенаправление на страни�
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Эта проблема может быть вызвана отключением или запретом принимать куки.</li>\n"
+"  <li>Эта проблема может быть вызвана отключением или запретом принимать "
+"куки.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +612,13 @@ msgstr "Неизвестный тип адреса"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Для открытия данного адреса вам, возможно, понадобится установить стороннее программное обеспечение.</li>\n"
+"  <li>Для открытия данного адреса вам, возможно, понадобится установить "
+"стороннее программное обеспечение.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +628,19 @@ msgstr "Не удалось установить защищённое соеди
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Это может быть проблемой с конфигурацией сервера или же кто-то пытается подменить нужный вам сервер другим.</li>\n"
-"  <li>Если в прошлом вы успешно соединялись с этим сервером, то, возможно, эта ошибка является временной. Попробуйте зайти позже.</li>\n"
+"  <li>Это может быть проблемой с конфигурацией сервера или же кто-то "
+"пытается подменить нужный вам сервер другим.</li>\n"
+"  <li>Если в прошлом вы успешно соединялись с этим сервером, то, "
+"возможно, эта ошибка является временной. Попробуйте зайти позже.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +685,12 @@ msgstr "Открыть ссылку в новой вкладке"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Сохранённые и отправленные фотографии <b>не будут удалены</b>, когда вы сотрёте историю %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Сохранённые и отправленные фотографии <b>не будут удалены</b>, когда вы "
+"сотрёте историю %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +699,13 @@ msgstr "Усильте свою приватность"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Поднимите приватный просмотр на новый уровень. Блокируйте рекламу и другое содержимое, которое может отслеживать вас и замедлять загрузку страниц."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Поднимите приватный просмотр на новый уровень. Блокируйте рекламу и "
+"другое содержимое, которое может отслеживать вас и замедлять загрузку "
+"страниц."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +714,12 @@ msgstr "Ваш поиск, Ваш Интернет"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Искали что-то другое? Выберите другую поисковую систему по умолчанию в настройках."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Искали что-то другое? Выберите другую поисковую систему по умолчанию в "
+"настройках."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +730,12 @@ msgstr "Добавьте ярлыки на домашний экран"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "С %1$s вы сможете быстро вернуться к любимым сайтам. Просто выберите «Добавить на домашний экран» из меню %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"С %1$s вы сможете быстро вернуться к любимым сайтам. Просто выберите "
+"«Добавить на домашний экран» из меню %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +746,13 @@ msgstr "Сделайте приватность своей привычкой"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Установите %1$s своим браузером по умолчанию и получите преимущества приватного веб-сёрфинга, когда вы открываете веб-страницы из других приложений."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Установите %1$s своим браузером по умолчанию и получите преимущества "
+"приватного веб-сёрфинга, когда вы открываете веб-страницы из других "
+"приложений."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +790,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Отмена"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +813,36 @@ msgstr "Открыть ссылку в выбранной вкладке"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Открыть"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/sk/app.po
+++ b/locales/sk/app.po
@@ -2,23 +2,23 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-21 20:09+0000\n"
 "Last-Translator: Juraj Cigáň <kusavica@gmail.com>\n"
-"Language-Team: sk <LL@li.org>\n"
 "Language: sk\n"
+"Language-Team: sk <LL@li.org>\n"
+"Plural-Forms: nplurals=4; plural=((((n >= 2 && n <= 4)) && ((0 == 0))) ? "
+"1 : (!((0 == 0))) ? 2 : (((n == 1)) && ((0 == 0))) ? 0 : 3)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +168,26 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s vám dáva kontrolu.</p>\n"
 "<p>Používajte ho ako súkromný prehliadač:\n"
 "  <ul>\n"
-"    <li>Vyhľadávajte a prehliadajte priamo prostredníctvom aplikácie</li>\n"
-"    <li>Blokujte sledovacie prvky (v nastaveniach môžete sledovacie prvky povoliť)</li>\n"
+"    <li>Vyhľadávajte a prehliadajte priamo prostredníctvom aplikácie</li>"
+"\n"
+"    <li>Blokujte sledovacie prvky (v nastaveniach môžete sledovacie prvky"
+" povoliť)</li>\n"
 "    <li>Vymažte cookies, históriu vyhľadávania a prehliadania</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s vyvíja Mozilla. Naša misia je podporovať zdravý a otvorený internet.<br/>\n"
+"<p>%1$s vyvíja Mozilla. Naša misia je podporovať zdravý a otvorený "
+"internet.<br/>\n"
 "<a href=\"%2$s\">Ďalšie informácie</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +288,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Odosielať anonymné údaje o používaní"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Ďalšie informácie"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +342,16 @@ msgstr "Vymazať históriu prehliadania"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Rozbaliť"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +462,12 @@ msgstr "Nájsť aplikáciu, ktorá môže otvoriť tento odkaz"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Žiadna aplikácia na vašom zariadení nie je schopná otvoriť tento odkaz. Môžete opustiť aplikáciu %1$s a nájsť vhodnú aplikáciu v %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Žiadna aplikácia na vašom zariadení nie je schopná otvoriť tento odkaz. "
+"Môžete opustiť aplikáciu %1$s a nájsť vhodnú aplikáciu v %2$s."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +492,9 @@ msgstr "Otvoriť"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Prevzaté súbory <b>nebudú odstránené</b> pri vymazaní histórie prehliadania aplikácie %1$s."
+msgstr ""
+"Prevzaté súbory <b>nebudú odstránené</b> pri vymazaní histórie "
+"prehliadania aplikácie %1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +527,17 @@ msgstr "Nie je možné sa pripojiť"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Stránka môže byť dočasne nedostupná alebo zaneprázdnená. Svoj pokus opakujte neskôr.</li>\n"
-"        <li>Ak sa nedá načítať žiadna stránka, skontrolujte pripojenie vášho mobilného zariadenia k internetu.</li>\n"
+"        <li>Stránka môže byť dočasne nedostupná alebo zaneprázdnená. Svoj"
+" pokus opakujte neskôr.</li>\n"
+"        <li>Ak sa nedá načítať žiadna stránka, skontrolujte pripojenie "
+"vášho mobilného zariadenia k internetu.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +554,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Skontrolujte, či ste nezadali napr.\n"
 "          <strong>ww</strong>.example.com namiesto\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Ak sa nedá načítať žiadna stránka, skontrolujte pripojenie vášho zariadenia k internetu.</li>\n"
+"        <li>Ak sa nedá načítať žiadna stránka, skontrolujte pripojenie "
+"vášho zariadenia k internetu.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +573,17 @@ msgstr "Adresa nie je platná"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Webové adresy sú zvyčajne zadávané v tvare <strong>http://www.example.com/</strong></li>\n"
-"  <li>Skontrolujte, či používate správne lomky (t.j. <strong>/</strong>).</li>\n"
+"  <li>Webové adresy sú zvyčajne zadávané v tvare "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Skontrolujte, či používate správne lomky (t.j. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +593,13 @@ msgstr "Stránku sa nepodarilo správne presmerovať"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Tento problém môže nastať pri nepovolení alebo odmietnutí cookies.</li>\n"
+"  <li>Tento problém môže nastať pri nepovolení alebo odmietnutí "
+"cookies.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +609,13 @@ msgstr "Adresa nebola rozpoznaná"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Na otvorenie tento adresy možno bude potrebné nainštalovať ďalší softvér.</li>\n"
+"  <li>Na otvorenie tento adresy možno bude potrebné nainštalovať ďalší "
+"softvér.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,9 +625,11 @@ msgstr "Zabezpečené pripojenie zlyhalo"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
@@ -629,8 +682,12 @@ msgstr "Otvoriť odkaz na novej karte"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Uložené a zdieľané obrázky <b>nebudú vymazané</b> pri vymazaní histórie aplikácie %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Uložené a zdieľané obrázky <b>nebudú vymazané</b> pri vymazaní histórie "
+"aplikácie %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -639,8 +696,12 @@ msgstr "Posuňte svoje súkromie na vyššiu úroveň"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Súkromné prehliadanie na úplne inej úrovni. Blokujte reklamy a ostatný obsah, ktorý vás môže sledovať naprieč stránkami."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Súkromné prehliadanie na úplne inej úrovni. Blokujte reklamy a ostatný "
+"obsah, ktorý vás môže sledovať naprieč stránkami."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -649,8 +710,12 @@ msgstr "Prehliadanie podľa vás"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Hľadáte niečo iné? Vyberte si iný predvolený vyhľadávací modul v nastaveniach."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Hľadáte niečo iné? Vyberte si iný predvolený vyhľadávací modul v "
+"nastaveniach."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -661,8 +726,13 @@ msgstr "Pridajte si na svoju domovskú obrazovku skratky"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "S aplikáciou %1$s sa môžete vrátiť ku svojim obľúbeným stránkam prakticky okamžite. Stačí ak v ponuke aplikácie %1$s vyberiete možnosť „Pridať na úvodnú obrazovku“."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"S aplikáciou %1$s sa môžete vrátiť ku svojim obľúbeným stránkam prakticky"
+" okamžite. Stačí ak v ponuke aplikácie %1$s vyberiete možnosť „Pridať na "
+"úvodnú obrazovku“."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -673,8 +743,13 @@ msgstr "Zvyknite si na súkromie"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Nastavte si %1$s ako svoj predvolený prehliadač a získajte výhody súkromného prehliadania vždy, keď otvoríte webové stránky z iných aplikácií."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Nastavte si %1$s ako svoj predvolený prehliadač a získajte výhody "
+"súkromného prehliadania vždy, keď otvoríte webové stránky z iných "
+"aplikácií."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -712,6 +787,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Zrušiť"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -727,3 +810,36 @@ msgstr "Otvoriť odkaz na zvolenej karte"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Otvoriť"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/sl/app.po
+++ b/locales/sl/app.po
@@ -2,23 +2,24 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-18 17:53+0000\n"
 "Last-Translator: Lan Glad <upwinxp@gmail.com>\n"
-"Language-Team: sl <LL@li.org>\n"
 "Language: sl\n"
+"Language-Team: sl <LL@li.org>\n"
+"Plural-Forms: nplurals=4; plural=(((((0 == 0)) && (((n % 100) >= 3 && (n "
+"% 100) <= 4))) || (!((0 == 0)))) ? 2 : (((0 == 0)) && (((n % 100) == 1)))"
+" ? 0 : (((0 == 0)) && (((n % 100) == 2))) ? 1 : 3)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +169,25 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s daje nadzor v vaše roke.</p>\n"
 "<p>Uporabljajte ga kot zaseben brskalnik:\n"
 "  <ul>\n"
 "    <li>Iščite in brskajte naravnost iz aplikacije</li>\n"
-"    <li>Zavračajte sledilce (ali spremenite nastavitve zavračanja sledilcev)</li>\n"
+"    <li>Zavračajte sledilce (ali spremenite nastavitve zavračanja "
+"sledilcev)</li>\n"
 "    <li>Brišite piškotke ter zgodovino strani in iskanja</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s razvija Mozilla. Naše poslanstvo je spodbujati zdrav in odprt internet.<br/>\n"
+"<p>%1$s razvija Mozilla. Naše poslanstvo je spodbujati zdrav in odprt "
+"internet.<br/>\n"
 "<a href=\"%2$s\">Več o tem</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +288,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Pošiljaj anonimne podatke o uporabi"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Več o tem"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +342,16 @@ msgstr "Počisti zgodovino brskanja"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Razširi"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +462,12 @@ msgstr "Poišči aplikacijo, ki lahko odpre povezavo"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Nobena aplikacija na napravi ne more odpreti te povezave. Lahko zapustite %1$s in v %2$s poiščete aplikacijo, ki jo lahko."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Nobena aplikacija na napravi ne more odpreti te povezave. Lahko zapustite"
+" %1$s in v %2$s poiščete aplikacijo, ki jo lahko."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -490,13 +525,17 @@ msgstr "Povezave ni mogoče vzpostaviti"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Stran trenutno morda ni na voljo ali je preobremenjena. Poskusite znova čez nekaj trenutkov.</li>\n"
-"        <li>Če ne morete naložiti nobene strani, na napravi preverite povezavo z omrežjem.</li>\n"
+"        <li>Stran trenutno morda ni na voljo ali je preobremenjena. "
+"Poskusite znova čez nekaj trenutkov.</li>\n"
+"        <li>Če ne morete naložiti nobene strani, na napravi preverite "
+"povezavo z omrežjem.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +552,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Preverite naslov za tipkarske napake, na primer\n"
 "          <strong>ww</strong>. example.com namesto\n"
 "          <strong>www</strong>. example.com</li>\n"
-"        <li>Če ne morete naložiti nobene strani, na napravi preverite povezavo z omrežjem.</li>\n"
+"        <li>Če ne morete naložiti nobene strani, na napravi preverite "
+"povezavo z omrežjem.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +571,17 @@ msgstr "Neveljaven naslov"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Spletne naslove se običajno piše v obliki <strong>http://www.example.com/</strong></li>\n"
-"  <li>Prepričajte se, da uporabljate poševnice naprej (t.j. <strong>/</strong>).</li>\n"
+"  <li>Spletne naslove se običajno piše v obliki "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Prepričajte se, da uporabljate poševnice naprej (t.j. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +591,13 @@ msgstr "Stran se ne preusmerja pravilno"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>To težavo običajno povzročajo onemogočeni ali zavrnjeni piškotki.</li>\n"
+"  <li>To težavo običajno povzročajo onemogočeni ali zavrnjeni "
+"piškotki.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +607,13 @@ msgstr "Naslova ni bilo mogoče razumeti"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Za odpiranje tega naslova boste morda morali namestiti dodaten program.</li>\n"
+"  <li>Za odpiranje tega naslova boste morda morali namestiti dodaten "
+"program.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,16 +623,19 @@ msgstr "Varna povezava ni uspela"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
 "  <li>Težava je morda v nastavitvah strežnika ali pa nekdo poskuša\n"
 "ta strežnik oponašati.</li>\n"
-"  <li>Če ste se v preteklosti že uspešno povezali na ta strežnik, je morda\n"
+"  <li>Če ste se v preteklosti že uspešno povezali na ta strežnik, je "
+"morda\n"
 "napaka začasna in lahko znova poskusite kasneje.</li>\n"
 "</ul>"
 
@@ -629,8 +681,12 @@ msgstr "Odpri povezavo v novem zavihku"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Ob izbrisu zgodovine %1$sa shranjene in deljene slike <b>ne bodo izbrisane</b>."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Ob izbrisu zgodovine %1$sa shranjene in deljene slike <b>ne bodo "
+"izbrisane</b>."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -639,8 +695,12 @@ msgstr "Okrepite svojo zasebnost"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Zasebno brskanje na višjem nivoju. Zavračajte oglase in drugo vsebino, ki vam lahko sledi prek strani, in pohitrite svoje brskanje."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Zasebno brskanje na višjem nivoju. Zavračajte oglase in drugo vsebino, ki"
+" vam lahko sledi prek strani, in pohitrite svoje brskanje."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -649,7 +709,9 @@ msgstr "Vaše iskanje, na vaš način"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "Iščete nekaj drugačnega? V nastavitvah izberite drug privzeti iskalnik."
 
 #. First run tour (Shortcut): Title
@@ -661,8 +723,12 @@ msgstr "Dodajte bližnjice na domač zaslon"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Hitro se vrnite na svoje priljubljene strani v %1$su. Preprosto izberite \"Dodaj na domač zaslon\" v %1$sovem meniju."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Hitro se vrnite na svoje priljubljene strani v %1$su. Preprosto izberite "
+"\"Dodaj na domač zaslon\" v %1$sovem meniju."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -673,8 +739,12 @@ msgstr "Naj zasebnost postane navada"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Nastavite %1$s kot privzet brskalnik in uživajte prednosti zasebnega brskanja, ko odprete spletne strani v drugih aplikacijah."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Nastavite %1$s kot privzet brskalnik in uživajte prednosti zasebnega "
+"brskanja, ko odprete spletne strani v drugih aplikacijah."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -712,6 +782,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Prekliči"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -727,3 +805,36 @@ msgstr "Odpri povezavo v izbranem zavihku"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Odpri"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/sq/app.po
+++ b/locales/sq/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-05-21 09:29+0000\n"
 "Last-Translator: Besnik Bleta <besnik@programeshqip.org>\n"
 "Language: sq\n"
@@ -287,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Dërgo të dhëna anonime përdorimi"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Mësoni më tepër"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -324,6 +340,16 @@ msgstr "Fshi historik shfletimesh"
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -747,6 +773,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr ""
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -761,5 +795,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/sr/app.po
+++ b/locales/sr/app.po
@@ -2,23 +2,26 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-18 10:16+0000\n"
 "Last-Translator: Marko Andrejić <marko.andrejic93@gmail.com>\n"
-"Language-Team: sr <LL@li.org>\n"
 "Language: sr\n"
+"Language-Team: sr <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=((((((0 == 0)) && (((n % 10) >= 2 && (n "
+"% 10) <= 4))) && (!(((n % 100) >= 12 && (n % 100) <= 14)))) || ((((0 % "
+"10) >= 2 && (0 % 10) <= 4)) && (!(((0 % 100) >= 12 && (0 % 100) <= "
+"14))))) ? 1 : (((((0 == 0)) && (((n % 10) == 1))) && (!(((n % 100) == "
+"11)))) || ((((0 % 10) == 1)) && (!(((0 % 100) == 11))))) ? 0 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,10 +171,12 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s вам даје контролу.</p>\n"
@@ -179,10 +184,12 @@ msgstr ""
 "  <ul>\n"
 "    <li>Претражујте и сурфујте директно у апликацији</li>\n"
 "    <li>Блокирајте пратиоце (или их омогућите у поставкама)</li>\n"
-"    <li>Избришите све колачиће као и историјат прегледања и претраге</li>\n"
+"    <li>Избришите све колачиће као и историјат прегледања и претраге</li>"
+"\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s је створила Mozilla. Наша мисија је неговање здравог и отвореног интернета.<br/>\n"
+"<p>%1$s је створила Mozilla. Наша мисија је неговање здравог и отвореног "
+"интернета.<br/>\n"
 "<a href=\"%2$s\">Сазнајте више</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +290,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Анонимно шаљи податке о коришћењу"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Сазнајте више"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +344,16 @@ msgstr "Избриши историјат прегледања"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Прошири"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +464,12 @@ msgstr "Пронађите апликацију која може отворит
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ниједна апликација на вашем уређају не може отворити ову везу. Можете угасити %1$s и претражити %2$s да бисте нашли неку."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ниједна апликација на вашем уређају не може отворити ову везу. Можете "
+"угасити %1$s и претражити %2$s да бисте нашли неку."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -490,13 +527,17 @@ msgstr "Повезивање није успело"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Сајт је можда тренутно недоступан или презаузет. Покушајте поново за пар минута.</li>\n"
-"        <li>Уколико не можете учитати странице, проверите интернет на вашем телефону или Wi-Fi конекцију.</li>\n"
+"        <li>Сајт је можда тренутно недоступан или презаузет. Покушајте "
+"поново за пар минута.</li>\n"
+"        <li>Уколико не можете учитати странице, проверите интернет на "
+"вашем телефону или Wi-Fi конекцију.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +554,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Проверите адресу ради грешака у куцању као што су\n"
 "          <strong>ww</strong>.example.com уместо\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Уколико не можете учитати странице, проверите интернет на вашем телефону или Wi-Fi конекцију.</li>\n"
+"        <li>Уколико не можете учитати странице, проверите интернет на "
+"вашем телефону или Wi-Fi конекцију.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,12 +573,15 @@ msgstr "Адреса је неважећа"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Веб адресе се обично пишу као <strong>http://www.example.com/</strong></li>\n"
+"  <li>Веб адресе се обично пишу као "
+"<strong>http://www.example.com/</strong></li>\n"
 "  <li>Уверите се да користите косе црте (тј. <strong>/</strong>).</li>\n"
 "</ul>"
 
@@ -546,11 +592,13 @@ msgstr "Страница се не преусмерава исправно"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Проблем понекад може бити изазван онемогућавањем или одбијањем прихватања колачића.</li>\n"
+"  <li>Проблем понекад може бити изазван онемогућавањем или одбијањем "
+"прихватања колачића.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +608,13 @@ msgstr "Нејасна адреса"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Можда ћете морати инсталирати други софтвер да бисте отворили ову адресу.</li>\n"
+"  <li>Можда ћете морати инсталирати други софтвер да бисте отворили ову "
+"адресу.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,15 +624,19 @@ msgstr "Безбедна веза није успостављена"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Ово би могао бити проблем са подешавањима сервера или се можда неко представља као сервер.</li>\n"
-"  <li>Ако сте се и раније успешно повезивали на овај сервер, грешка може бити привремена и можете поново покушати касније да му приступите.</li>\n"
+"  <li>Ово би могао бити проблем са подешавањима сервера или се можда неко"
+" представља као сервер.</li>\n"
+"  <li>Ако сте се и раније успешно повезивали на овај сервер, грешка може "
+"бити привремена и можете поново покушати касније да му приступите.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -627,8 +681,12 @@ msgstr "Отвори везу у новом језичку"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Сачуване и дељене слике <b>неће бити обрисане</b> када обришете %1$s историјат."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Сачуване и дељене слике <b>неће бити обрисане</b> када обришете %1$s "
+"историјат."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -637,8 +695,12 @@ msgstr "Ојачајте вашу приватност"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Унапредите приватно прегледање. Блокирајте рекламе и други саржај који вас прати путем сајтова и убрзајте учитавање страница."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Унапредите приватно прегледање. Блокирајте рекламе и други саржај који "
+"вас прати путем сајтова и убрзајте учитавање страница."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -647,8 +709,12 @@ msgstr "Ваше претраге, ваш начин"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Тражите нешто другачије? Изаберите други подразумевани претраживач у поставкама."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Тражите нешто другачије? Изаберите други подразумевани претраживач у "
+"поставкама."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -659,8 +725,12 @@ msgstr "Додајте пречице на вашем почетном екра�
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Вратите се на ваше омиљене сајтове у %1$s-у лако. Само изаберите \"Додај на екран телефона\" из %1$s менија."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Вратите се на ваше омиљене сајтове у %1$s-у лако. Само изаберите \"Додај "
+"на екран телефона\" из %1$s менија."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -671,8 +741,12 @@ msgstr "Учините приватност навиком"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Поставите %1$s као ваш подразумевани прегледач и искусите приватно прегледање када отворите веб странице из других апликација."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Поставите %1$s као ваш подразумевани прегледач и искусите приватно "
+"прегледање када отворите веб странице из других апликација."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -710,6 +784,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Откажи"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +807,36 @@ msgstr "Отвори везу у изабраном језичку"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Отвори"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/sv-SE/app.po
+++ b/locales/sv-SE/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-19 07:40+0000\n"
 "Last-Translator: Andreas Pettersson <az@kth.se>\n"
-"Language-Team: sv_SE <LL@li.org>\n"
 "Language: sv_SE\n"
+"Language-Team: sv_SE <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 1)) && ((0 == 0))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,25 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s ger dig full kontroll.</p>\n"
 "<p>Använd den som en privat webbläsare:\n"
 "  <ul>\n"
 "    <li>Sök och surfa direkt i appen</li>\n"
-"    <li>Blockera trackers (eller uppdatera inställningar att tillåta trackers)</li>\n"
+"    <li>Blockera trackers (eller uppdatera inställningar att tillåta "
+"trackers)</li>\n"
 "    <li>Radera för att ta bort kakor samt sök- och webbhistorik</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s är utvecklad av Mozilla. Vårt uppdrag är att främja ett hälsosamt, öppet Internet.<br/>\n"
+"<p>%1$s är utvecklad av Mozilla. Vårt uppdrag är att främja ett "
+"hälsosamt, öppet Internet.<br/>\n"
 "<a href=\"%2$s\">Läs mer</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +286,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Skicka anonym användardata"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Läs mer"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +340,16 @@ msgstr "Radera webbhistorik"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Expandera"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +460,12 @@ msgstr "Hitta en app som kan öppna länken"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ingen av apparna på din enhet kan öppna denna länk. Du kan lämna %1$s för att söka i %2$s efter en app som kan göra detta."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ingen av apparna på din enhet kan öppna denna länk. Du kan lämna %1$s för"
+" att söka i %2$s efter en app som kan göra detta."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -457,7 +490,9 @@ msgstr "Öppna"
 #. Focus).
 msgctxt "download_dialog_warning"
 msgid "Downloaded files <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Hämtade filer <b>kommer inte att raderas</b> när du raderar historik för %1$s."
+msgstr ""
+"Hämtade filer <b>kommer inte att raderas</b> när du raderar historik för "
+"%1$s."
 
 #. Title of download dialogue
 msgctxt "download_dialog_title"
@@ -490,13 +525,17 @@ msgstr "Det går inte att ansluta"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Webbplatsen kan vara tillfälligt otillgänglig eller alltför upptagen. Försök igen om en stund.</li>\n"
-"        <li>Om du inte kan öppna några sidor, kontrollera den mobila enhetens data eller WiFi-anslutning.</li>\n"
+"        <li>Webbplatsen kan vara tillfälligt otillgänglig eller alltför "
+"upptagen. Försök igen om en stund.</li>\n"
+"        <li>Om du inte kan öppna några sidor, kontrollera den mobila "
+"enhetens data eller WiFi-anslutning.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +552,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Kontrollera adressen efter skrivfel såsom\n"
 "          <strong>ww</strong>.example.com istället för\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Om du inte kan öppna några sidor, kontrollera enhetens data eller WiFi-anslutning.</li>\n"
+"        <li>Om du inte kan öppna några sidor, kontrollera enhetens data "
+"eller WiFi-anslutning.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,12 +571,15 @@ msgstr "Adressen är inte giltig"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Webbadresser skrivs vanligen som <strong>http://www.example.com/</strong></li>\n"
+"  <li>Webbadresser skrivs vanligen som "
+"<strong>http://www.example.com/</strong></li>\n"
 "  <li>Se till att du använder snedstreck (i.e. <strong>/</strong>).</li>\n"
 "</ul>"
 
@@ -546,11 +590,13 @@ msgstr "Sidan omdirigerar inte korrekt"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Detta problem kan ibland uppstå om du inaktiverat eller nekat att acceptera kakor.</li>\n"
+"  <li>Detta problem kan ibland uppstå om du inaktiverat eller nekat att "
+"acceptera kakor.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +606,13 @@ msgstr "Adressen kan inte tolkas"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Du kan behöva installera andra program för att öppna den här adressen.</li>\n"
+"  <li>Du kan behöva installera andra program för att öppna den här "
+"adressen.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,16 +622,20 @@ msgstr "Säker anslutning misslyckades"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Det kan vara ett problem med serverns konfiguration, eller det kan vara\n"
+"  <li>Det kan vara ett problem med serverns konfiguration, eller det kan "
+"vara\n"
 "någon som försöker imitera servern.</li>\n"
-"  <li>Om du har anslutit till den här servern med framgång i det förflutna, kan felet\n"
+"  <li>Om du har anslutit till den här servern med framgång i det "
+"förflutna, kan felet\n"
 "vara tillfälligt, och du kan försöka igen senare.</li>\n"
 "</ul>"
 
@@ -629,8 +681,12 @@ msgstr "Öppna länk i ny flik"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Sparade och delade bilder <b>kommer inte att raderas</b> när du raderar %1$s historik."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Sparade och delade bilder <b>kommer inte att raderas</b> när du raderar "
+"%1$s historik."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -639,8 +695,12 @@ msgstr "Stärk din integritet"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Ta privat surfning till nästa nivå. Blockera annonser och annat innehåll som kan spåra dig på webbplatser och slöa ner laddningen av webbsidor."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Ta privat surfning till nästa nivå. Blockera annonser och annat innehåll "
+"som kan spåra dig på webbplatser och slöa ner laddningen av webbsidor."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -649,8 +709,12 @@ msgstr "Sök som du vill"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Letar du efter något annat? Välj en annan standardsökmotor i Inställningar."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Letar du efter något annat? Välj en annan standardsökmotor i "
+"Inställningar."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -661,8 +725,12 @@ msgstr "Lägg till genvägar till startskärmen"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Återgå till dina favoritwebbplatser i %1$s snabbt. Välj \"Lägg till på startskärmen\" från menyn %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Återgå till dina favoritwebbplatser i %1$s snabbt. Välj \"Lägg till på "
+"startskärmen\" från menyn %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -673,8 +741,12 @@ msgstr "Låt integritet bli en vana"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Ange %1$s som standardwebbläsare och dra nytta av fördelarna med privat surfning när du öppnar webbsidor från andra appar."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Ange %1$s som standardwebbläsare och dra nytta av fördelarna med privat "
+"surfning när du öppnar webbsidor från andra appar."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -712,6 +784,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Avbryt"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -727,3 +807,36 @@ msgstr "Öppna länk i vald flik"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Öppna"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/ta/app.po
+++ b/locales/ta/app.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-07-31 02:03+0000\n"
 "Last-Translator: அருண் குமார் (Arun Kumar) <thangam.arunx@gmail.com>\n"
 "Language: ta\n"
@@ -285,9 +285,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "பெயரற்ற பயனளவு தரவை அனுப்பு"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "மேலும் அறிய"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -322,6 +338,16 @@ msgstr "உலாவல் வரலாற்றை அகற்று"
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -747,6 +773,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "ரத்து"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -761,5 +795,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/te/app.po
+++ b/locales/te/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-18 06:30+0000\n"
 "Last-Translator: Sahithi <sahithi.thinker@gmail.com>\n"
-"Language-Team: te <LL@li.org>\n"
 "Language: te\n"
+"Language-Team: te <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -166,21 +165,25 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s పగ్గాలను మీ చేతుల్లో పెడుతుంది.</p>\n"
 "<p>దీన్ని అంతరంగిక విహరిణిగా వాడుకోండి:\n"
 "  <ul>\n"
 "    <li>నేరుగా యాప్ లోనే వెతకండి, విహరించండి</li>\n"
-"    <li>ట్రాకర్లను నిరోధించుకోండి (లేదా ట్రాకర్లను అనుమతించడానికి అమరికలలో మార్చుకోండి)</li>\n"
+"    <li>ట్రాకర్లను నిరోధించుకోండి (లేదా ట్రాకర్లను అనుమతించడానికి "
+"అమరికలలో మార్చుకోండి)</li>\n"
 "    <li>కుకీలను అలాగే వెతుకుడు, విహరణ చరిత్రలను తుడిచివేసుకోండి</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$sని Mozilla తయారుచేసింది. ఆరోగ్యకరమైన, స్వేచ్ఛా జాలాన్ని ప్రోత్సహించడం మా ఆశయం.<br/>\n"
+"<p>%1$sని Mozilla తయారుచేసింది. ఆరోగ్యకరమైన, స్వేచ్ఛా జాలాన్ని "
+"ప్రోత్సహించడం మా ఆశయం.<br/>\n"
 "<a href=\"%2$s\">ఇంకా తెలుసుకోండి</a></p>"
 
 msgctxt "preference_category_search"
@@ -281,9 +284,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "అనామక వాడుక దత్తాంశాన్ని పంపించు"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "ఇంకా తెలుసుకోండి"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -319,6 +338,16 @@ msgstr "విహరణ చరిత్రను తుడిచేయి"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "విస్తరింపచేయి"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -429,8 +458,12 @@ msgstr "లింక్ను తెరవగల అనువర్తనాన�
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "మీ పరికరంలోని అనువర్తనాల్లో ఏదీ ఈ లింక్ను తెరవలేకపోతుంది. మీరు చేయగల అనువర్తనం కోసం %2$sను శోధించడానికి %1$sను వదిలివేయవచ్చు."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"మీ పరికరంలోని అనువర్తనాల్లో ఏదీ ఈ లింక్ను తెరవలేకపోతుంది. మీరు చేయగల "
+"అనువర్తనం కోసం %2$sను శోధించడానికి %1$sను వదిలివేయవచ్చు."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -488,13 +521,17 @@ msgstr "అనుసంధానం సాధ్యం కావడంలేద�
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>సైట్ తాత్కాలికంగా అందుబాటులో లేకపోవచ్చు లేదా చాలా బిజీగా ఉండవచ్చు. కొద్ది క్షణాలలో మళ్ళీ ప్రయత్నించండి.</li>\n"
-"        <li>మీరు ఏ పేజీలను లోడ్ చేయలేకపోతే, మీ మొబైల్ పరికర డేటా లేదా Wi-Fi కనెక్షన్ను తనిఖీ చేయండి.</li>\n"
+"        <li>సైట్ తాత్కాలికంగా అందుబాటులో లేకపోవచ్చు లేదా చాలా బిజీగా "
+"ఉండవచ్చు. కొద్ది క్షణాలలో మళ్ళీ ప్రయత్నించండి.</li>\n"
+"        <li>మీరు ఏ పేజీలను లోడ్ చేయలేకపోతే, మీ మొబైల్ పరికర డేటా లేదా "
+"Wi-Fi కనెక్షన్ను తనిఖీ చేయండి.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -511,7 +548,8 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
@@ -522,7 +560,8 @@ msgstr ""
 "          \n"
 "          <strong>www</strong>.example.com</li>\n"
 "        \n"
-"        <li>మీరు ఏ పేజీలను లోడ్ చేయలేకపోతే, మీ పరికర డేటా లేదా Wi-Fi కనెక్షన్ను తనిఖీ చేయండి.</li>\n"
+"        <li>మీరు ఏ పేజీలను లోడ్ చేయలేకపోతే, మీ పరికర డేటా లేదా Wi-Fi "
+"కనెక్షన్ను తనిఖీ చేయండి.</li>\n"
 "      \n"
 "      </ul>"
 
@@ -533,15 +572,19 @@ msgstr "ఈ చిరునామా సరైనది కాదు"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
 "  \n"
-"  <li>వెబ్ చిరునామాలను సాధారణంగా వ్రాస్తారు <strong>http://www.example.com/</strong></li>\n"
+"  <li>వెబ్ చిరునామాలను సాధారణంగా వ్రాస్తారు "
+"<strong>http://www.example.com/</strong></li>\n"
 "  \n"
-"  <li>మీరు ముందుకు శ్లాష్లు ఉపయోగిస్తున్నారని నిర్ధారించుకోండి (అనగా<strong>/</strong>).</li>\n"
+"  <li>మీరు ముందుకు శ్లాష్లు ఉపయోగిస్తున్నారని నిర్ధారించుకోండి "
+"(అనగా<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -551,12 +594,14 @@ msgstr "ఈ పేజ్ సరిగా మళ్ళించుట లేద�
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "\n"
 "<ul>\n"
-"  <li>కూకీలను అచేనతనం చేయడం వల్లగానీ లేదా వాటిని అంగీకరించకపోవడం వల్ల గానీ కొన్నిసార్లు ఈ సమస్య రావచ్చు.</li>\n"
+"  <li>కూకీలను అచేనతనం చేయడం వల్లగానీ లేదా వాటిని అంగీకరించకపోవడం వల్ల "
+"గానీ కొన్నిసార్లు ఈ సమస్య రావచ్చు.</li>\n"
 "</ul>\n"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -566,12 +611,14 @@ msgstr "ఆ చిరునామా అర్థం కాలేదు"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
 "  \n"
-"  <li>ఈచిరునామాను తెరువుటకు మీరు వేరే సాఫ్టువేరును స్థాపించుకోవలిసిన అవసరం ఉండవచ్చు.</li></ul>"
+"  <li>ఈచిరునామాను తెరువుటకు మీరు వేరే సాఫ్టువేరును స్థాపించుకోవలిసిన "
+"అవసరం ఉండవచ్చు.</li></ul>"
 
 msgctxt "error_sslhandshake_title"
 msgid "Secure connection failed"
@@ -580,15 +627,19 @@ msgstr "రక్షిత అనుసంధానం విఫలమైంద�
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>ఇది సర్వర్ యొక్క కాన్ఫిగరేషన్తో సమస్య కావచ్చు లేదా సర్వర్ను ప్రతిరూపం చేసుకోవడానికి ఎవరైనా ప్రయత్నిస్తుండవచ్చు</li>\n"
-"  <li>గతంలో ఈ సర్వర్కు మీరు విజయవంతంగా కనెక్ట్ అయినట్లయితే, లోపం తాత్కాలికంగా ఉండవచ్చు మరియు మీరు తర్వాత మళ్లీ ప్రయత్నించవచ్చు.</li>\n"
+"  <li>ఇది సర్వర్ యొక్క కాన్ఫిగరేషన్తో సమస్య కావచ్చు లేదా సర్వర్ను "
+"ప్రతిరూపం చేసుకోవడానికి ఎవరైనా ప్రయత్నిస్తుండవచ్చు</li>\n"
+"  <li>గతంలో ఈ సర్వర్కు మీరు విజయవంతంగా కనెక్ట్ అయినట్లయితే, లోపం "
+"తాత్కాలికంగా ఉండవచ్చు మరియు మీరు తర్వాత మళ్లీ ప్రయత్నించవచ్చు.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -633,8 +684,12 @@ msgstr "లంకెను కొత్త ట్యాబులో తెరు
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "మీరు %1$s చరిత్రను తీసివేసినప్పుడు సేవ్ చేయబడిన మరియు పంచిన చిత్రాలు <b> తొలగించబడవు </b>."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"మీరు %1$s చరిత్రను తీసివేసినప్పుడు సేవ్ చేయబడిన మరియు పంచిన చిత్రాలు <b> "
+"తొలగించబడవు </b>."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -643,7 +698,9 @@ msgstr "మీ ప్రైవసీని శక్తిమంతం చేస
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
 msgstr ""
 
 #. First run tour (Search): Title
@@ -653,7 +710,9 @@ msgstr ""
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr ""
 
 #. First run tour (Shortcut): Title
@@ -665,7 +724,9 @@ msgstr ""
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
 msgstr ""
 
 #. First run tour (Privacy): Title
@@ -677,7 +738,9 @@ msgstr ""
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
 msgstr ""
 
 msgctxt "firstrun_close_button"
@@ -716,6 +779,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "రద్దుచేయి"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -731,3 +802,36 @@ msgstr ""
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "తెరువు"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/templates/app.pot
+++ b/locales/templates/app.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -270,8 +270,24 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr ""
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
+msgstr ""
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
 msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
@@ -307,6 +323,16 @@ msgstr ""
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -694,6 +720,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr ""
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -708,5 +742,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/th/app.po
+++ b/locales/th/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-25 20:45+0000\n"
 "Last-Translator: Top <teerapatxtop@yahoo.com>\n"
-"Language-Team: th <LL@li.org>\n"
 "Language: th\n"
+"Language-Team: th <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,10 +167,12 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s ให้คุณได้ควบคุม</p>\n"
@@ -182,7 +183,8 @@ msgstr ""
 "    <li>ล้างเพื่อลบคุกกี้รวมทั้งประวัติการค้นหาและการท่องเว็บ</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s ถูกสร้างขึ้นโดย Mozilla ภารกิจของเราคือส่งเสริมอินเทอร์เน็ตที่สมบูรณ์และเปิดกว้าง<br/>\n"
+"<p>%1$s ถูกสร้างขึ้นโดย Mozilla "
+"ภารกิจของเราคือส่งเสริมอินเทอร์เน็ตที่สมบูรณ์และเปิดกว้าง<br/>\n"
 "<a href=\"%2$s\">เรียนรู้เพิ่มเติม</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +285,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "ส่งข้อมูลการใช้งานแบบไม่ระบุตัวตน"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "เรียนรู้เพิ่มเติม"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +339,16 @@ msgstr "ล้างประวัติการท่องเว็บ"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "ขยาย"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +459,12 @@ msgstr "ค้นหาแอปที่สามารถเปิดลิง
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "ไม่มีแอปในอุปกรณ์ของคุณที่สามารถเปิดลิงก์นี้ คุณสามารถออกจาก %1$s เพื่อค้นหา %2$s สำหรับแอปที่สามารถทำได้"
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"ไม่มีแอปในอุปกรณ์ของคุณที่สามารถเปิดลิงก์นี้ คุณสามารถออกจาก %1$s "
+"เพื่อค้นหา %2$s สำหรับแอปที่สามารถทำได้"
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -490,13 +522,17 @@ msgstr "ไม่สามารถเชื่อมต่อ"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>ไซต์อาจใช้งานไม่ได้ชั่วคราวหรือกำลังทำงานหนักเกินไป ลองอีกครั้งในอีกสักครู่</li>\n"
-"        <li>หากคุณไม่สามารถโหลดหน้าใด ๆ ได้ ตรวจสอบการเชื่อมต่อข้อมูลหรือ Wi-Fi ของอุปกรณ์มือถือของคุณ</li>\n"
+"        <li>ไซต์อาจใช้งานไม่ได้ชั่วคราวหรือกำลังทำงานหนักเกินไป "
+"ลองอีกครั้งในอีกสักครู่</li>\n"
+"        <li>หากคุณไม่สามารถโหลดหน้าใด ๆ ได้ ตรวจสอบการเชื่อมต่อข้อมูลหรือ"
+" Wi-Fi ของอุปกรณ์มือถือของคุณ</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,12 +549,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>ตรวจสอบข้อผิดพลาดในการพิมพ์ที่อยู่ อย่างเช่น <strong>ww</strong>.example.com แทนที่จะเป็น <strong>www</strong>.example.com</li>\n"
-"        <li>หากคุณไม่สามารถโหลดหน้าใด ๆ ได้ ตรวจสอบการเชื่อมต่อข้อมูลหรือ Wi-Fi ของอุปกรณ์ของคุณ</li>\n"
+"        <li>ตรวจสอบข้อผิดพลาดในการพิมพ์ที่อยู่ อย่างเช่น "
+"<strong>ww</strong>.example.com แทนที่จะเป็น "
+"<strong>www</strong>.example.com</li>\n"
+"        <li>หากคุณไม่สามารถโหลดหน้าใด ๆ ได้ ตรวจสอบการเชื่อมต่อข้อมูลหรือ"
+" Wi-Fi ของอุปกรณ์ของคุณ</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -528,13 +568,17 @@ msgstr "ที่อยู่ไม่ถูกต้อง"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>ที่อยู่เว็บมักจะเขียนเป็น <strong>http://www.example.com/</strong></li>\n"
-"  <li>ตรวจสอบให้แน่ใจว่าคุณใช้เครื่องหมายทับไปข้างหน้า (กล่าวคือ <strong>/</strong>)</li>\n"
+"  <li>ที่อยู่เว็บมักจะเขียนเป็น "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>ตรวจสอบให้แน่ใจว่าคุณใช้เครื่องหมายทับไปข้างหน้า (กล่าวคือ "
+"<strong>/</strong>)</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -544,11 +588,14 @@ msgstr "หน้าไม่ได้เปลี่ยนเส้นทาง
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>ปัญหานี้บางครั้งอาจมีสาเหตุมาจากการปิดใช้งานหรือปฏิเสธการยอมรับคุกกี้</li>\n"
+"  "
+"<li>ปัญหานี้บางครั้งอาจมีสาเหตุมาจากการปิดใช้งานหรือปฏิเสธการยอมรับคุกกี้</li>"
+"\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -558,7 +605,8 @@ msgstr "ไม่เข้าใจที่อยู่"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -572,15 +620,20 @@ msgstr "การเชื่อมต่อปลอดภัยล้มเห
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>สิ่งนี้อาจเป็นปัญหาจากการกำหนดค่าของเซิร์ฟเวอร์ หรืออาจมีใครบางคนกำลังพยายามปลอมแปลงเซิร์ฟเวอร์</li>\n"
-"  <li>หากคุณเคยเชื่อมต่อกับเซิร์ฟเวอร์นี้สำเร็จในอดีต ข้อผิดพลาดอาจเกิดขึ้นเพียงชั่วคราว และคุณสามารถลองอีกครั้งในภายหลัง</li>\n"
+"  <li>สิ่งนี้อาจเป็นปัญหาจากการกำหนดค่าของเซิร์ฟเวอร์ "
+"หรืออาจมีใครบางคนกำลังพยายามปลอมแปลงเซิร์ฟเวอร์</li>\n"
+"  <li>หากคุณเคยเชื่อมต่อกับเซิร์ฟเวอร์นี้สำเร็จในอดีต "
+"ข้อผิดพลาดอาจเกิดขึ้นเพียงชั่วคราว และคุณสามารถลองอีกครั้งในภายหลัง</li>"
+"\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -625,7 +678,9 @@ msgstr "เปิดลิงก์ในแท็บใหม่"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
 msgstr "ภาพที่บันทึกไว้และแบ่งปัน<b>จะไม่ถูกลบ</b>เมื่อคุณล้างประวัติของ %1$s"
 
 #. First run tour (Default browser): Title
@@ -635,8 +690,12 @@ msgstr "เพิ่มความเป็นส่วนตัวของค
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "นำการท่องเว็บแบบส่วนตัวไปสู่ระดับถัดไป ปิดกั้นโฆษณาและเนื้อหาอื่น ๆ ที่สามารถติดตามคุณระหว่างไซต์และลดเวลาในการโหลดหน้า"
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"นำการท่องเว็บแบบส่วนตัวไปสู่ระดับถัดไป ปิดกั้นโฆษณาและเนื้อหาอื่น ๆ "
+"ที่สามารถติดตามคุณระหว่างไซต์และลดเวลาในการโหลดหน้า"
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -645,7 +704,9 @@ msgstr "การค้นหาของคุณในแบบของคุ
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "กำลังค้นหาอย่างอื่น? เลือกเครื่องมือค้นหาเริ่มต้นอื่นในการตั้งค่า"
 
 #. First run tour (Shortcut): Title
@@ -657,8 +718,12 @@ msgstr "เพิ่มทางลัดไปยังหน้าจอหล
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "กลับไปที่ไซต์โปรดของคุณใน %1$s ได้อย่างรวดเร็ว เพียงเลือก \"เพิ่มไปยังหน้าจอหลัก\" จากเมนู %1$s"
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"กลับไปที่ไซต์โปรดของคุณใน %1$s ได้อย่างรวดเร็ว เพียงเลือก "
+"\"เพิ่มไปยังหน้าจอหลัก\" จากเมนู %1$s"
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -669,8 +734,13 @@ msgstr "สร้างนิสัยความเป็นส่วนตั
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "ตั้ง %1$s เป็นเบราว์เซอร์เริ่มต้นของคุณและรับประโยชน์จากการท่องเว็บแบบส่วนตัวเมื่อคุณเปิดหน้าเว็บจากแอปอื่น ๆ"
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"ตั้ง %1$s "
+"เป็นเบราว์เซอร์เริ่มต้นของคุณและรับประโยชน์จากการท่องเว็บแบบส่วนตัวเมื่อคุณเปิดหน้าเว็บจากแอปอื่น"
+" ๆ"
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -708,6 +778,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "ยกเลิก"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -723,3 +801,36 @@ msgstr "เปิดลิงก์ในแท็บที่เลือก"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "เปิด"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/tr/app.po
+++ b/locales/tr/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-26 13:12+0000\n"
 "Last-Translator: Selim Şumlu <selim@sum.lu>\n"
-"Language-Team: tr <LL@li.org>\n"
 "Language: tr\n"
+"Language-Team: tr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +167,27 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s kontrolü size verir.</p>\n"
 "<p>Onu gizlilik odaklı bir tarayıcı olarak kullanabilirsiniz:\n"
 "  <ul>\n"
-"    <li>Doğrudan uygulamada arama yapabilir ve web’de gezinebilirsiniz</li>\n"
-"    <li>Takipçileri engelleyebilirsiniz (veya belli takipçilere izin verebilirsiniz)</li>\n"
-"    <li>Tek düğmeyle çerezleri, arama ve gezinti geçmişinizi silebilirsiniz</li>\n"
+"    <li>Doğrudan uygulamada arama yapabilir ve web’de "
+"gezinebilirsiniz</li>\n"
+"    <li>Takipçileri engelleyebilirsiniz (veya belli takipçilere izin "
+"verebilirsiniz)</li>\n"
+"    <li>Tek düğmeyle çerezleri, arama ve gezinti geçmişinizi "
+"silebilirsiniz</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s Mozilla tarafından geliştirilmiştir. Misyonumuz daha sağlıklı ve açık bir internet yaratmaktır.<br/>\n"
+"<p>%1$s Mozilla tarafından geliştirilmiştir. Misyonumuz daha sağlıklı ve "
+"açık bir internet yaratmaktır.<br/>\n"
 "<a href=\"%2$s\">Daha fazla bilgi alın</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +288,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Anonim kullanım verilerini gönder"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Daha fazla bilgi al"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +342,16 @@ msgstr "Gezinti geçmişini sil"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Genişlet"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +462,12 @@ msgstr "Bağlantıyı açabilecek bir uygulama bul"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Cihazınızdaki uygulamalar bu bağlantıyı açamıyor. %2$s mağazasında uygun bir uygulama aramak için %1$s'tan çıkabilirsiniz."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Cihazınızdaki uygulamalar bu bağlantıyı açamıyor. %2$s mağazasında uygun "
+"bir uygulama aramak için %1$s'tan çıkabilirsiniz."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -490,13 +525,17 @@ msgstr "Bağlanılamadı"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Site geçici olarak kapalı olabilir veya çok meşgul olabilir. Birkaç dakika sonra yeniden deneyin.</li>\n"
-"        <li>Hiçbir sayfa açılmıyorsa cihazınızın mobil internet veya Wi-Fi bağlantısını kontrol edin.</li>\n"
+"        <li>Site geçici olarak kapalı olabilir veya çok meşgul olabilir. "
+"Birkaç dakika sonra yeniden deneyin.</li>\n"
+"        <li>Hiçbir sayfa açılmıyorsa cihazınızın mobil internet veya Wi-"
+"Fi bağlantısını kontrol edin.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,12 +552,15 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Adres <strong>www</strong>.example.com yerine <strong>ww</strong>.example.com gibi yanlış yazılmış olabilir.</li>\n"
-"  <li>Hiçbir sayfa açılmıyorsa cihazınızın mobil internet veya Wi-Fi bağlantısını kontrol edin.</li>\n"
+"  <li>Adres <strong>www</strong>.example.com yerine "
+"<strong>ww</strong>.example.com gibi yanlış yazılmış olabilir.</li>\n"
+"  <li>Hiçbir sayfa açılmıyorsa cihazınızın mobil internet veya Wi-Fi "
+"bağlantısını kontrol edin.</li>\n"
 "</ul>"
 
 msgctxt "error_malformedURI_title"
@@ -528,13 +570,17 @@ msgstr "Adres geçersiz"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Web adresleri genelde <strong>http://www.example.com/</strong> biçiminde yazılır.</li>\n"
-"  <li>Adreste sağa yatık bölü işareti (<strong>/</strong>) bulunduğundan emin olun.</li>\n"
+"  <li>Web adresleri genelde <strong>http://www.example.com/</strong> "
+"biçiminde yazılır.</li>\n"
+"  <li>Adreste sağa yatık bölü işareti (<strong>/</strong>) bulunduğundan "
+"emin olun.</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -544,11 +590,13 @@ msgstr "Sayfa doğru bir şekilde yönlendirilmiyor"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Bu sorun bazen çerezlerin devre dışı bırakılmasından veya reddedilmesinden kaynaklabilir.</li>\n"
+"  <li>Bu sorun bazen çerezlerin devre dışı bırakılmasından veya "
+"reddedilmesinden kaynaklabilir.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -558,11 +606,13 @@ msgstr "Adres anlaşılamadı"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Bu adresi açmak için başka bir uygulama yüklemeniz gerekebilir.</li>\n"
+"  <li>Bu adresi açmak için başka bir uygulama yüklemeniz "
+"gerekebilir.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -572,15 +622,19 @@ msgstr "Güvenli bağlantı hatası"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul> \n"
-"  <li>Sunucunun yapılandırmasıyla ilgili bir sorun olabilir veya birisi sunucuyu taklit etmeye çalışıyor olabilir.</li>\n"
-"  <li>Daha önce bu sunucuya sorunsuz bağlandıysanız sorun geçici olabilir ve daha sonra yeniden bağlanmayı deneyebilirsiniz.</li>\n"
+"  <li>Sunucunun yapılandırmasıyla ilgili bir sorun olabilir veya birisi "
+"sunucuyu taklit etmeye çalışıyor olabilir.</li>\n"
+"  <li>Daha önce bu sunucuya sorunsuz bağlandıysanız sorun geçici olabilir"
+" ve daha sonra yeniden bağlanmayı deneyebilirsiniz.</li>\n"
 "</ul>"
 
 msgctxt "error_generic_title"
@@ -625,8 +679,12 @@ msgstr "Bağlantıyı yeni sekmede aç"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "%1$s geçmişini sildiğinizde, kaydettiğiniz ve paylaştığınız resimler <b>silinmeyecektir</b>."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"%1$s geçmişini sildiğinizde, kaydettiğiniz ve paylaştığınız resimler "
+"<b>silinmeyecektir</b>."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -635,8 +693,13 @@ msgstr "Gizliliğini güçlendir"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Gizli gezintiyi daha da geliştirdik. Gezdiğiniz siteleri takip eden ve sayfaların yüklenmesini yavaşlatan reklamları ve diğer içerikleri engelleyebilirsiniz."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Gizli gezintiyi daha da geliştirdik. Gezdiğiniz siteleri takip eden ve "
+"sayfaların yüklenmesini yavaşlatan reklamları ve diğer içerikleri "
+"engelleyebilirsiniz."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -645,8 +708,12 @@ msgstr "Senin araman, senin kararın"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
-msgstr "Başka bir şey mi arıyorsunuz? Ayarlar menüsünden varsayılan arama motorunuzu değiştirebilirsiniz."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
+msgstr ""
+"Başka bir şey mi arıyorsunuz? Ayarlar menüsünden varsayılan arama "
+"motorunuzu değiştirebilirsiniz."
 
 #. First run tour (Shortcut): Title
 msgctxt "firstrun_shortcut_title"
@@ -657,8 +724,12 @@ msgstr "Kısayolları ana ekranınıza ekleyin"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "%1$s’ta sevdiğiniz sitelere çabucak ulaşabilirsiniz. %1$s menüsünden \"Ana ekrana ekle\"yi seçmeniz yeterli."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"%1$s’ta sevdiğiniz sitelere çabucak ulaşabilirsiniz. %1$s menüsünden "
+"\"Ana ekrana ekle\"yi seçmeniz yeterli."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -669,8 +740,12 @@ msgstr "Hep gizli kalın"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "%1$s’u varsayılan tarayıcınız yapın, diğer uygulamalarda web sayfalarını açtığınız zaman da gizli gezintiden yararlanın."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"%1$s’u varsayılan tarayıcınız yapın, diğer uygulamalarda web sayfalarını "
+"açtığınız zaman da gizli gezintiden yararlanın."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -708,6 +783,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "İptal"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -723,3 +806,36 @@ msgstr "Bağlantıyı seçili sekmede aç"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Aç"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/uk/app.po
+++ b/locales/uk/app.po
@@ -2,23 +2,27 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-18 13:40+0000\n"
 "Last-Translator: Artem Polivanchuk <a.polivanchuk@outlook.com>\n"
-"Language-Team: uk <LL@li.org>\n"
 "Language: uk\n"
+"Language-Team: uk <LL@li.org>\n"
+"Plural-Forms: nplurals=4; plural=(((((0 == 0)) && (((n % 10) >= 2 && (n %"
+" 10) <= 4))) && (!(((n % 100) >= 12 && (n % 100) <= 14)))) ? 1 : (((((0 "
+"== 0)) && (((n % 10) == 0))) || (((0 == 0)) && (((n % 10) >= 5 && (n % "
+"10) <= 9)))) || (((0 == 0)) && (((n % 100) >= 11 && (n % 100) <= 14)))) ?"
+" 2 : ((((0 == 0)) && (((n % 10) == 1))) && (!(((n % 100) == 11)))) ? 0 : "
+"3)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,21 +172,25 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s надає вам контроль.</p>\n"
 "<p>Використовуйте його в якості приватного браузера:\n"
 "  <ul>\n"
 "    <li>Здійснюйте пошук і перегляд безпосередньо в програмі</li>\n"
-"    <li>Блокуйте стеження (або змініть налаштування, щоб дозволити його)</li>\n"
+"    <li>Блокуйте стеження (або змініть налаштування, щоб дозволити "
+"його)</li>\n"
 "    <li>Видаляйте куки, а також історію пошуку та перегляду</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s створено в Mozilla. Нашою місією є сприяння розвитку здорового та відкритого Інтернету.<br/>\n"
+"<p>%1$s створено в Mozilla. Нашою місією є сприяння розвитку здорового та"
+" відкритого Інтернету.<br/>\n"
 "<a href=\"%2$s\">Докладніше</a></p>"
 
 msgctxt "preference_category_search"
@@ -283,9 +291,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "Надсилати анонімні дані використання"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "Докладніше"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +345,16 @@ msgstr "Стерти історію перегляду"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "Розгорнути"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,8 +465,12 @@ msgstr "Знайдіть програму, яка може відкрити по
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Жодна з програм на вашому пристрої не здатна відкрити це посилання. Ви можете вийти з %1$s для пошуку відповідної програми у %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Жодна з програм на вашому пристрої не здатна відкрити це посилання. Ви "
+"можете вийти з %1$s для пошуку відповідної програми у %2$s."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -490,13 +528,17 @@ msgstr "Не вдалося з'єднатися"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>Сайт може бути тимчасово недоступний або перевантажений. Спробуйте знову через деякий час.</li>\n"
-"        <li>Якщо ви не можете завантажити жодної сторінки, перевірте з'єднання вашого пристрою з мобільною або Wi-Fi мережею.</li>\n"
+"        <li>Сайт може бути тимчасово недоступний або перевантажений. "
+"Спробуйте знову через деякий час.</li>\n"
+"        <li>Якщо ви не можете завантажити жодної сторінки, перевірте "
+"з'єднання вашого пристрою з мобільною або Wi-Fi мережею.</li>\n"
 "      </ul>"
 
 msgctxt "error_timeout_title"
@@ -513,14 +555,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
 "        <li>Перевірте адресу на помилки, такі як\n"
 "          <strong>ww</strong>.example.com замість\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>Якщо ви не можете завантажити жодної сторінки, перевірте з'єднання вашого пристрою з мобільною або Wi-Fi мережею.</li>\n"
+"        <li>Якщо ви не можете завантажити жодної сторінки, перевірте "
+"з'єднання вашого пристрою з мобільною або Wi-Fi мережею.</li>\n"
 "      </ul>"
 
 msgctxt "error_malformedURI_title"
@@ -530,13 +574,17 @@ msgstr "Формат адреси неправильний"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Веб-адреси зазвичай записуються у вигляді <strong>http://www.example.com/</strong></li>\n"
-"  <li>Переконайтеся, що ви використовуєте дробову риску (тобто <strong>/</strong>).</li>\n"
+"  <li>Веб-адреси зазвичай записуються у вигляді "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Переконайтеся, що ви використовуєте дробову риску (тобто "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -546,11 +594,13 @@ msgstr "Неналежне перенаправлення на сторінці"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Інколи ця проблема може бути спричиненою вимкненням або забороною приймати куки.</li>\n"
+"  <li>Інколи ця проблема може бути спричиненою вимкненням або забороною "
+"приймати куки.</li>\n"
 "</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -560,11 +610,13 @@ msgstr "Незрозуміла адреса"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
-"  <li>Для відкриття даної адреси вам, можливо, необхідно встановити додаткове програмне забезпечення.</li>\n"
+"  <li>Для відкриття даної адреси вам, можливо, необхідно встановити "
+"додаткове програмне забезпечення.</li>\n"
 "</ul>"
 
 msgctxt "error_sslhandshake_title"
@@ -574,16 +626,19 @@ msgstr "Не вдалося встановити безпечне з’єдна�
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
 "  <li>Це може бути проблемою конфігурації сервера, або хтось намагається\n"
 " видати себе за цей сервер.</li>\n"
-"  <li>Якщо ви раніше успішно підключалися до цього сервера, помилка може \n"
+"  <li>Якщо ви раніше успішно підключалися до цього сервера, помилка може"
+" \n"
 "бути тимчасовою і ви можете повторити спробу пізніше.</li>\n"
 "</ul>"
 
@@ -629,8 +684,12 @@ msgstr "Відкрити посилання в новій вкладці"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
-msgstr "Збережені та поширені зображення <b>не видаляються</b> при стиранні історії %1$s."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
+msgstr ""
+"Збережені та поширені зображення <b>не видаляються</b> при стиранні "
+"історії %1$s."
 
 #. First run tour (Default browser): Title
 msgctxt "firstrun_defaultbrowser_title"
@@ -639,8 +698,13 @@ msgstr "Прокачайте вашу приватність"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
-msgstr "Перейдіть на вищий рівень приватного перегляду. Блокуйте рекламу та інший вміст, що може стежити за вами на сайтах і сповільнювати завантаження сторінок."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
+msgstr ""
+"Перейдіть на вищий рівень приватного перегляду. Блокуйте рекламу та інший"
+" вміст, що може стежити за вами на сайтах і сповільнювати завантаження "
+"сторінок."
 
 #. First run tour (Search): Title
 msgctxt "firstrun_search_title"
@@ -649,7 +713,9 @@ msgstr "Ваш пошук, ваш шлях"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "Шукаєте щось інше? Оберіть інший пошуковий засіб в налаштуваннях."
 
 #. First run tour (Shortcut): Title
@@ -661,8 +727,12 @@ msgstr "Додавайте ярлики на головний екран"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
-msgstr "Швидко відкривайте свої улюблені сайти у %1$s. Просто оберіть \"Додати на головний екран\" в меню %1$s."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
+msgstr ""
+"Швидко відкривайте свої улюблені сайти у %1$s. Просто оберіть \"Додати на"
+" головний екран\" в меню %1$s."
 
 #. First run tour (Privacy): Title
 msgctxt "firstrun_privacy_title"
@@ -673,8 +743,12 @@ msgstr "Зробіть приватність звичкою"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
-msgstr "Встановіть %1$s своїм типовим браузером та отримайте переваги приватного перегляду при переході на веб-сайти з інших програм."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
+msgstr ""
+"Встановіть %1$s своїм типовим браузером та отримайте переваги приватного "
+"перегляду при переході на веб-сайти з інших програм."
 
 msgctxt "firstrun_close_button"
 msgid "OK, got it!"
@@ -712,6 +786,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "Скасувати"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -727,3 +809,36 @@ msgstr "Відкривайте посилання у вибраній вклад
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "Відкрити"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/ur/app.po
+++ b/locales/ur/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-07 09:29+0000\n"
 "Last-Translator: um.qshi <um.qshi@gmail.com>\n"
 "Language: ur\n"
@@ -287,9 +287,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "گمنام استعمال شدہ کوائف ارسال کریں"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "مزید سیکھیں"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -324,6 +340,16 @@ msgstr "برائوزنگ سابقات مٹائیں"
 #. or erasing the browsing history.
 msgctxt "content_description_fab_expand"
 msgid "Expand"
+msgstr ""
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
 msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
@@ -748,6 +774,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "منسوخ کریں"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -762,5 +796,37 @@ msgstr ""
 #. the new link in the selected           existing tab.
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
+msgstr ""
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
 msgstr ""
 

--- a/locales/zh-CN/app.po
+++ b/locales/zh-CN/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-19 03:05+0000\n"
 "Last-Translator: xcffl <xcffl@outlook.com>\n"
+"Language: zh_Hans_CN\n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
-"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -168,10 +167,12 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s 让您掌控线上生活。</p>\n"
@@ -283,9 +284,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "发送匿名的使用统计数据"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "详细了解"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -321,6 +338,16 @@ msgstr "清除浏览记录"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "展开"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -431,7 +458,9 @@ msgstr "寻找可以打开此链接的应用"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
 msgstr "您的设备上的应用都不能打开此链接。您可以离开 %1$s，到 %2$s 找找适合的应用。"
 
 #. This label is shown above a list of apps that can be used to open a given
@@ -490,8 +519,10 @@ msgstr "无法连接"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
@@ -513,7 +544,8 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
@@ -530,8 +562,10 @@ msgstr "地址无效"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -546,7 +580,8 @@ msgstr "此页面不正确地重定向"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -560,7 +595,8 @@ msgstr "无法理解该地址"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -574,9 +610,11 @@ msgstr "安全连接失败"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
@@ -627,7 +665,9 @@ msgstr "在新标签页打开链接"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
 msgstr "清除 %1$s 的历史记录时，<b>不会删除</b>已保存和已分享的图像。"
 
 #. First run tour (Default browser): Title
@@ -637,7 +677,9 @@ msgstr "强化您的隐私"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
 msgstr "隐私浏览模式变得更强大了。能拦截广告，还能拦截在不同网站跟踪您，又拖慢网页载入的内容。"
 
 #. First run tour (Search): Title
@@ -647,7 +689,9 @@ msgstr "用你的方式搜你所寻"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "想搜点不一样的东西？可在设置里选择换个默认搜索引擎。"
 
 #. First run tour (Shortcut): Title
@@ -659,7 +703,9 @@ msgstr "在主屏幕中添加快捷方式"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
 msgstr "快速用 %1$s 回到您喜爱的网站。只需在 %1$s 菜单中选择“添加到主屏幕”。"
 
 #. First run tour (Privacy): Title
@@ -671,7 +717,9 @@ msgstr "让隐私成为一种习惯"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
 msgstr "将 %1$s 设为您的默认浏览器，用其他应用打开网页时即可享受隐私浏览。"
 
 msgctxt "firstrun_close_button"
@@ -710,6 +758,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "取消"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -725,3 +781,36 @@ msgstr "指定用来打开链接的标签页"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "打开"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+

--- a/locales/zh-TW/app.po
+++ b/locales/zh-TW/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-08-16 13:49+0200\n"
+"POT-Creation-Date: 2017-08-28 12:48+0200\n"
 "PO-Revision-Date: 2017-08-16 16:45+0000\n"
 "Last-Translator: Pin-guang Chen <petercpg@mail.moztw.org>\n"
+"Language: zh_Hant_TW\n"
 "Language-Team: zh_Hant_TW <LL@li.org>\n"
-"Language: zh_TW\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -166,10 +165,12 @@ msgid ""
 "  <ul>\n"
 "    <li>Search and browse right in the app</li>\n"
 "    <li>Block trackers (or update settings to allow trackers)</li>\n"
-"    <li>Erase to delete cookies as well as search and browsing history</li>\n"
+"    <li>Erase to delete cookies as well as search and browsing "
+"history</li>\n"
 "  </ul>\n"
 "</p>\n"
-"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open Internet.<br/>\n"
+"<p>%1$s is produced by Mozilla. Our mission is to foster a healthy, open "
+"Internet.<br/>\n"
 "<a href=\"%2$s\">Learn more</a></p>"
 msgstr ""
 "<p>%1$s 讓您可自行控制線上生活。</p>\n"
@@ -281,9 +282,25 @@ msgctxt "preference_mozilla_telemetry"
 msgid "Send anonymous usage data"
 msgstr "傳送匿名的使用統計資料"
 
+#. A link to SUMO at the end of the summary
+#. (preference_mozilla_telemetry_summary2) of the "Send anonymous usage data"
+#. setting.
 msgctxt "preference_mozilla_telemetry_summary"
 msgid "Learn more"
 msgstr "了解更多"
+
+#. %1$s will be replaced with the name of the app (e.g. Firefox Focus)
+#, c-format
+msgctxt "preference_mozilla_telemetry_summary2"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone."
+msgstr ""
+
+#. In-app link (in settings) to Focus privacy notice.
+msgctxt "preference_privacy_notice"
+msgid "Privacy Notice"
+msgstr ""
 
 #. Item in Preferences that shows the about page. Parameter 1 is the app name,
 #. i.e. Firefox Focus/Firefox Klar.
@@ -319,6 +336,16 @@ msgstr "清除瀏覽紀錄"
 msgctxt "content_description_fab_expand"
 msgid "Expand"
 msgstr "展開"
+
+#. If the user has multiple tabs open we will show an addition "floating
+#. action button" showing how many tabs are open.      This string is not
+#. displayed and read only by screenreaders. %1$s will be replaced with the
+#. number of open tabs. This       button will only be visible when there is
+#. more than one tab open (>= 2).
+#, c-format
+msgctxt "content_description_tab_counter"
+msgid "Tabs open: %1$s"
+msgstr ""
 
 #. Description of the "+" button used to open a new temporary tab ("open" is a
 #. verb), not displayed and read only by screenreaders.
@@ -429,7 +456,9 @@ msgstr "尋找可開啟此鏈結的應用程式"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
 msgstr "您裝置中並未安裝可開啟此鏈結的應用程式。您可離開 %1$s，到 %2$s 安裝一套。"
 
 #. This label is shown above a list of apps that can be used to open a given
@@ -488,10 +517,14 @@ msgstr "無法連線"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
-msgstr "<ul><li>網站可能太忙碌或暫時無法使用，請稍候再試一次。</li><li>若您無法載入任何頁面，請檢查您的數據或 Wi-Fi 連線。</li></ul>"
+msgstr ""
+"<ul><li>網站可能太忙碌或暫時無法使用，請稍候再試一次。</li><li>若您無法載入任何頁面，請檢查您的數據或 Wi-Fi "
+"連線。</li></ul>"
 
 msgctxt "error_timeout_title"
 msgid "The connection timed out"
@@ -507,9 +540,12 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
-msgstr "<ul><li>請檢查網址是否有打錯？例如把 <strong>www</strong>.example.com 打成 <strong>ww</strong>.example.com</li><li>若無法載入任何網站，請檢查您的網路連線狀態。</li></ul>"
+msgstr ""
+"<ul><li>請檢查網址是否有打錯？例如把 <strong>www</strong>.example.com 打成 "
+"<strong>ww</strong>.example.com</li><li>若無法載入任何網站，請檢查您的網路連線狀態。</li></ul>"
 
 msgctxt "error_malformedURI_title"
 msgid "The address isn’t valid"
@@ -518,10 +554,15 @@ msgstr "網址無效"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
-msgstr "<ul><li>網址通常長得像 <strong>http://www.example.com/</strong>。</li><li>請確定您用的是斜線 (例: <strong>/</strong>)。</li> </ul>"
+msgstr ""
+"<ul><li>網址通常長得像 "
+"<strong>http://www.example.com/</strong>。</li><li>請確定您用的是斜線 (例: "
+"<strong>/</strong>)。</li> </ul>"
 
 msgctxt "error_redirectLoop_title"
 msgid "The page isn’t redirecting properly"
@@ -530,7 +571,8 @@ msgstr "頁面重新導向不正確"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr "<ul> <li>有時候停用或拒絕接受 Cookie 會造成此問題。</li> </ul>"
 
@@ -541,7 +583,8 @@ msgstr "無法理解的網址"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr "<ul><li>您可能需要安裝其他軟體才能開啟此網址。</li></ul>"
 
@@ -552,12 +595,16 @@ msgstr "安全連線失敗"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
-msgstr "<ul><li>可能是伺服器設定問題造成，或是有人嘗試偽裝成該伺服器。</li><li>若您以前可以與該伺服器正常連線，那麼這個錯誤可能只是暫時的，請稍候再試試看。</li> </ul>"
+msgstr ""
+"<ul><li>可能是伺服器設定問題造成，或是有人嘗試偽裝成該伺服器。</li><li>若您以前可以與該伺服器正常連線，那麼這個錯誤可能只是暫時的，請稍候再試試看。</li>"
+" </ul>"
 
 msgctxt "error_generic_title"
 msgid "Oops"
@@ -601,7 +648,9 @@ msgstr "用新分頁開啟鏈結"
 #. an image). %1$s will be replaced with the long name of the app (e.g. Firefox
 #. Focus).
 msgctxt "contextmenu_image_warning"
-msgid "Saved and shared images <b>will not be deleted</b> when you erase %1$s history."
+msgid ""
+"Saved and shared images <b>will not be deleted</b> when you erase %1$s "
+"history."
 msgstr "清除 %1$s 瀏覽紀錄時，已儲存並分享的圖片將<b>不會被刪除</b>。"
 
 #. First run tour (Default browser): Title
@@ -611,7 +660,9 @@ msgstr "加強您的隱私"
 
 #. First run tour (Default browser): Text.
 msgctxt "firstrun_defaultbrowser_text2"
-msgid "Take private browsing to the next level. Block ads and other content that can track you across sites and bog down page load times."
+msgid ""
+"Take private browsing to the next level. Block ads and other content that"
+" can track you across sites and bog down page load times."
 msgstr "隱私瀏覽功能變得更強大了。現在可封鎖廣告，以及其他可在不同網站間追蹤您的上網紀錄，又拖慢網頁載入的追蹤器。"
 
 #. First run tour (Search): Title
@@ -621,7 +672,9 @@ msgstr "用你的方式搜尋"
 
 #. First run tour (Search): Text
 msgctxt "firstrun_search_text"
-msgid "Searching for something different? Choose another default search engine in Settings."
+msgid ""
+"Searching for something different? Choose another default search engine "
+"in Settings."
 msgstr "想找點不一樣的東西嗎？可在設定畫面中選擇不同的預設搜尋引擎。"
 
 #. First run tour (Shortcut): Title
@@ -633,7 +686,9 @@ msgstr "在主畫面加入捷徑"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_shortcut_text"
-msgid "Return to your favorite sites in %1$s quickly. Just select \"Add to Home screen\" from the %1$s menu."
+msgid ""
+"Return to your favorite sites in %1$s quickly. Just select \"Add to Home "
+"screen\" from the %1$s menu."
 msgstr "只要選擇 %1$s 選單中的「新增至裝置主畫面」即可快速用 %1$s 回到您最愛的網站。"
 
 #. First run tour (Privacy): Title
@@ -645,7 +700,9 @@ msgstr "讓隱私成為一種習慣。"
 #. app (e.g. Firefox Focus)
 #, c-format
 msgctxt "firstrun_privacy_text"
-msgid "Set %1$s as your default browser and get the benefits of private browsing when you open webpages from other apps."
+msgid ""
+"Set %1$s as your default browser and get the benefits of private browsing"
+" when you open webpages from other apps."
 msgstr "將 %1$s 設為您的預設瀏覽器，從其他程式開啟網頁時即可直接進入隱私瀏覽模式從中受益。"
 
 msgctxt "firstrun_close_button"
@@ -684,6 +741,14 @@ msgctxt "dialog_addtohomescreen_action_cancel"
 msgid "Cancel"
 msgstr "取消"
 
+#. When tracking protection is disabled for the current session then we will
+#. show this warning in the "Add to home screen" dialog to          let the
+#. user know that the shortcut will always be opened with tracking protection
+#. disabled.
+msgctxt "dialog_addtohomescreen_tracking_protection"
+msgid "Shortcut will open with Tracking Protection disabled"
+msgstr ""
+
 #. When the limit of concurrent tabs is reached and the user wants to open
 #. another tab then we show a dialog to select a tab          that will be
 #. overridden with the new link. This is the title of the dialog where the user
@@ -699,3 +764,36 @@ msgstr "指定用來開啟鏈結的分頁"
 msgctxt "dialog_opentab_action_open"
 msgid "Open"
 msgstr "開啟"
+
+#. The user visible name of the "notification channel" (Android 8+ feature)
+#. for the ongoing notification shown while a browsing session is active.
+#. The recommended maximum length is 40 characters; the value may be truncated
+#. if it is too long.      * To understand what notification channels are, see:
+#. https://www.androidcentral.com/notification-channels     * To see how this
+#. string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+msgctxt "notification_browsing_session_channel_name"
+msgid "Private browsing session"
+msgstr ""
+
+#. The user visible description of the "notification channel" (Android 8+
+#. feature) for the ongoing notification shown while a browsing session is
+#. active.     The recommended maximum length is 300 characters; the value may
+#. be truncated if it is too long. %1$s will be replaced with the name of the
+#. app (e.g. Firefox Focus).      * To understand what notification channels
+#. are, see: https://www.androidcentral.com/notification-channels     * To see
+#. how this string will look like in Android's UI, see:
+#. https://github.com/mozilla-mobile/focus-android/issues/863#issuecomment-324105723
+#, c-format
+msgctxt "notification_browsing_session_channel_description"
+msgid ""
+"Notifications let you erase your %1$s session with a tap. You don’t need "
+"to open the app or see what’s running in your browser."
+msgstr ""
+
+#. Label for a button in the "tabs tray" to erase the browsing history (closes
+#. all tabs and removes associated data).
+msgctxt "tabs_tray_action_erase"
+msgid "Erase browsing history"
+msgstr ""
+


### PR DESCRIPTION
Those are the new strings for the Cobalt release.

String freeze was supposed to be Aug 24, 2017 - but we delayed it to due to the changed Burgundy deadlines.

https://wiki.mozilla.org/Mobile/Focus/Android/Train_Schedule